### PR TITLE
feat(arco/Slider): add formatTooltip slot

### DIFF
--- a/packages/arco-lib/src/components/Slider.tsx
+++ b/packages/arco-lib/src/components/Slider.tsx
@@ -37,13 +37,19 @@ export const Slider = implementRuntimeComponent({
     properties: SliderPropsSpec,
     state: SliderStateSpec,
     methods: {},
-    slots: {},
+    slots: {
+      tooltip: {
+        slotProps: Type.Object({
+          value: Type.Number(),
+        }),
+      },
+    },
     styleSlots: ['content'],
     events: ['onChange', 'onAfterChange'],
   },
 })(props => {
   const { ...cProps } = getComponentProps(props);
-  const { customStyle, elementRef, callbackMap, mergeState } = props;
+  const { customStyle, slotsElements, elementRef, callbackMap, mergeState } = props;
 
   return (
     <BaseSlider
@@ -56,6 +62,9 @@ export const Slider = implementRuntimeComponent({
         mergeState({ value: val });
         callbackMap?.onAfterChange?.();
       }}
+      formatTooltip={val =>
+        slotsElements.tooltip ? slotsElements.tooltip({ value: val }) : <span>{val}</span>
+      }
       className={css(customStyle?.content)}
       {...cProps}
     />


### PR DESCRIPTION
<img width="1314" alt="image" src="https://user-images.githubusercontent.com/96771399/177912058-ebfd50a3-26e8-40c8-8737-81eede7f9cca.png">
The tooltip can now be formatted with formatTooltip slot