### PR TITLE
feat(runtime): pass slot fallback into slot elements

### DIFF
--- a/examples/tabs/index.json
+++ b/examples/tabs/index.json
@@ -77,6 +77,28 @@
           ]
         },
         {
+          "id": "text_2",
+          "type": "core/v1/text",
+          "properties": {
+            "value": {
+              "raw": "also in tab3",
+              "format": "plain"
+            }
+          },
+          "traits": [
+            {
+              "type": "core/v1/slot",
+              "properties": {
+                "container": {
+                  "id": "nested_tabs",
+                  "slot": "content"
+                },
+                "ifCondition": "{{ $slot.tabIndex === 0 }}"
+              }
+            }
+          ]
+        },
+        {
           "id": "nested_tabs",
           "type": "chakra_ui/v1/tabs",
           "properties": {

--- a/examples/tabs/index.json
+++ b/examples/tabs/index.json
@@ -70,7 +70,8 @@
                 "container": {
                   "id": "nested_tabs",
                   "slot": "content"
-                }
+                },
+                "ifCondition": "{{ $slot.tabIndex === 0 }}"
               }
             }
           ]

--- a/packages/chakra-ui-lib/src/components/Tabs.tsx
+++ b/packages/chakra-ui-lib/src/components/Tabs.tsx
@@ -101,9 +101,7 @@ export default implementRuntimeComponent({
                 ${customStyle?.tabContent}
               `}
             >
-              {slotsElements?.content
-                ? slotsElements.content({ tabIndex: idx })
-                : placeholder}
+              {slotsElements?.content?.({ tabIndex: idx }, placeholder)}
             </TabPanel>
           );
         })}

--- a/packages/runtime/src/components/_internal/ImplWrapper/ImplWrapper.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper/ImplWrapper.tsx
@@ -22,7 +22,8 @@ export const ImplWrapper = React.memo<ImplWrapperProps>(
       isEqual &&
       prevComponent === nextComponent &&
       // TODO: keep ImplWrapper memorized and get slot props from store
-      shallowCompare(prevProps.slotProps, nextProps.slotProps)
+      shallowCompare(prevProps.slotProps, nextProps.slotProps) &&
+      shallowCompare(prevProps.slotFallback, nextProps.slotFallback)
     );
   }
 );

--- a/packages/runtime/src/components/_internal/ImplWrapper/ImplWrapper.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper/ImplWrapper.tsx
@@ -23,7 +23,7 @@ export const ImplWrapper = React.memo<ImplWrapperProps>(
       prevComponent === nextComponent &&
       // TODO: keep ImplWrapper memorized and get slot props from store
       shallowCompare(prevProps.slotProps, nextProps.slotProps) &&
-      shallowCompare(prevProps.slotFallback, nextProps.slotFallback)
+      shallowCompare(prevProps.slotContext, nextProps.slotContext)
     );
   }
 );

--- a/packages/runtime/src/components/_internal/ImplWrapper/ImplWrapperMain.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper/ImplWrapperMain.tsx
@@ -161,7 +161,7 @@ export const ImplWrapperMain = React.forwardRef<HTMLDivElement, ImplWrapperProps
       <Impl
         ref={ref}
         key={c.id}
-        {...omit(props, ['slotProps', 'slotFallback'])}
+        {...omit(props, ['slotProps', 'slotContext'])}
         {...mergedProps}
         slotsElements={slotElements}
         mergeState={mergeState}

--- a/packages/runtime/src/components/_internal/ImplWrapper/ImplWrapperMain.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper/ImplWrapperMain.tsx
@@ -161,7 +161,7 @@ export const ImplWrapperMain = React.forwardRef<HTMLDivElement, ImplWrapperProps
       <Impl
         ref={ref}
         key={c.id}
-        {...omit(props, 'slotProps')}
+        {...omit(props, ['slotProps', 'slotFallback'])}
         {...mergedProps}
         slotsElements={slotElements}
         mergeState={mergeState}

--- a/packages/runtime/src/components/_internal/ImplWrapper/UnmountImplWrapper.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper/UnmountImplWrapper.tsx
@@ -8,7 +8,7 @@ import { watch } from '../../..';
 
 export const UnmountImplWrapper = React.forwardRef<HTMLDivElement, ImplWrapperProps>(
   function UnmountImplWrapper(props, ref) {
-    const { component: c, services } = props;
+    const { component: c, services, slotFallback } = props;
     const { stateManager, registry } = services;
     const { executeTrait } = useRuntimeFunctions(props);
 
@@ -76,6 +76,10 @@ export const UnmountImplWrapper = React.forwardRef<HTMLDivElement, ImplWrapperPr
       initSingleComponentState(registry, stateManager, c);
     }
 
-    return !isHidden ? <ImplWrapperMain {...props} ref={ref} /> : null;
+    return !isHidden ? (
+      <ImplWrapperMain {...props} ref={ref} />
+    ) : slotFallback ? (
+      <>{slotFallback}</>
+    ) : null;
   }
 );

--- a/packages/runtime/src/components/_internal/ImplWrapper/UnmountImplWrapper.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper/UnmountImplWrapper.tsx
@@ -8,7 +8,7 @@ import { watch } from '../../..';
 
 export const UnmountImplWrapper = React.forwardRef<HTMLDivElement, ImplWrapperProps>(
   function UnmountImplWrapper(props, ref) {
-    const { component: c, services, slotFallback } = props;
+    const { component: c, services, slotContext } = props;
     const { stateManager, registry } = services;
     const { executeTrait } = useRuntimeFunctions(props);
 
@@ -76,10 +76,12 @@ export const UnmountImplWrapper = React.forwardRef<HTMLDivElement, ImplWrapperPr
       initSingleComponentState(registry, stateManager, c);
     }
 
-    return !isHidden ? (
-      <ImplWrapperMain {...props} ref={ref} />
-    ) : slotFallback ? (
-      <>{slotFallback}</>
-    ) : null;
+    if (isHidden && slotContext) {
+      slotContext.renderSet.delete(c.id);
+      if (slotContext.renderSet.size === 0) {
+        return <>{slotContext.fallback}</>;
+      }
+    }
+    return !isHidden ? <ImplWrapperMain {...props} ref={ref} /> : null;
   }
 );

--- a/packages/runtime/src/components/_internal/ImplWrapper/hooks/useSlotChildren.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper/hooks/useSlotChildren.tsx
@@ -17,8 +17,10 @@ export function getSlotElements(
       return <ImplWrapper key={child.id} {...props} component={child} />;
     });
 
-    slotElements[slot] = function getSlot(slotProps) {
-      return slotChildren.map(child => React.cloneElement(child, { slotProps }));
+    slotElements[slot] = function getSlot(slotProps, slotFallback) {
+      return slotChildren.map(child =>
+        React.cloneElement(child, { slotProps, slotFallback })
+      );
     };
   }
   return slotElements;

--- a/packages/runtime/src/components/_internal/ImplWrapper/hooks/useSlotChildren.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper/hooks/useSlotChildren.tsx
@@ -18,9 +18,19 @@ export function getSlotElements(
     });
 
     slotElements[slot] = function getSlot(slotProps, slotFallback) {
-      return slotChildren.map(child =>
-        React.cloneElement(child, { slotProps, slotFallback })
+      const slotContext = {
+        renderSet: new Set(childrenMap[c.id][slot].map(child => child.id)),
+        parentId: c.id,
+        slotProps: JSON.stringify(slotProps),
+        fallback: slotFallback,
+      };
+      const children = slotChildren.map(child =>
+        React.cloneElement(child, {
+          slotProps,
+          slotContext,
+        })
       );
+      return children;
     };
   }
   return slotElements;

--- a/packages/runtime/src/types/component.ts
+++ b/packages/runtime/src/types/component.ts
@@ -21,7 +21,7 @@ export type ImplWrapperProps<
   app: RuntimeApplication;
   evalListItem?: boolean;
   slotProps?: unknown;
-  slotFallback?: React.ReactNode;
+  slotContext?: { renderSet: Set<string>; fallback?: React.ReactNode };
 } & ComponentParamsFromApp;
 
 export type ComponentImplProps<

--- a/packages/runtime/src/types/component.ts
+++ b/packages/runtime/src/types/component.ts
@@ -21,6 +21,7 @@ export type ImplWrapperProps<
   app: RuntimeApplication;
   evalListItem?: boolean;
   slotProps?: unknown;
+  slotFallback?: React.ReactNode;
 } & ComponentParamsFromApp;
 
 export type ComponentImplProps<
@@ -70,7 +71,10 @@ type SubscribeMethods<U> = (map: {
 }) => void;
 type MergeState<T> = (partialState: Partial<T>) => void;
 export type SlotsElements<U extends Record<string, SlotSpec>> = {
-  [K in keyof U]?: (props: Static<U[K]['slotProps']>) => React.ReactNode;
+  [K in keyof U]?: (
+    props: Static<U[K]['slotProps']>,
+    fallback?: React.ReactNode
+  ) => React.ReactNode;
 };
 
 export type RuntimeFunctions<


### PR DESCRIPTION
Previously, we introduce if condition to the slot trait, which helps
render slot element conditionally. But it is not easy for a component
developer to implement fallback UI of a slot, because neither the
if condition is true or false, the slot elements function will return
the ImplWrapperMain component.

This patch brings a new way to implement fallback UI: pass the
fallback UI as the second parameter of the slot elements function.
So in the ImplWrapper, we can fall back to the passed in UI.

Before:
<img width="630" alt="image" src="https://user-images.githubusercontent.com/13651389/178552460-c018f46f-2ad2-45a8-9976-f2199309b85d.png">

After:
<img width="725" alt="image" src="https://user-images.githubusercontent.com/13651389/178552492-8400d9ba-207f-4bbc-a31b-4b395ce88bc7.png">
