### PR TITLE
fix(styleTraitForm): fix nested button warning

### DIFF
--- a/packages/editor/src/components/ComponentForm/StyleTraitForm/StyleTraitForm.tsx
+++ b/packages/editor/src/components/ComponentForm/StyleTraitForm/StyleTraitForm.tsx
@@ -169,6 +169,7 @@ export const StyleTraitForm: React.FC<Props> = props => {
                 size="sm"
                 variant="ghost"
                 colorScheme="red"
+                as="div"
                 icon={<CloseIcon fontSize="12px" />}
                 onClick={removeStyle}
               />


### PR DESCRIPTION
Because <button> cannot be nested, so i render the inner button as div.
<img width="540" alt="截屏2022-07-13 下午5 37 06" src="https://user-images.githubusercontent.com/12260952/178702716-330e310e-3076-4b06-9423-9d8f25c42195.png">
