### PR TITLE
fix(paste): paste component into the first slot instead of 'content' slot

### DIFF
--- a/packages/editor/src/components/KeyboardEventWrapper.tsx
+++ b/packages/editor/src/components/KeyboardEventWrapper.tsx
@@ -29,6 +29,15 @@ export const KeyboardEventWrapper: React.FC<Props> = ({
     }
   `;
 
+  function getComponentFirstSlot(componentId: string) {
+    const component = components.find(c => c.id === componentId);
+    if (component) {
+      const spec = registry.getComponentByType(component?.type);
+      return Object.keys(spec.spec.slots)[0] || '';
+    }
+    return '';
+  }
+
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     switch (e.key) {
       case 'Delete':
@@ -103,7 +112,7 @@ export const KeyboardEventWrapper: React.FC<Props> = ({
               'operation',
               genOperation(registry, 'pasteComponent', {
                 parentId: selectedComponentId || RootId,
-                slot: 'content',
+                slot: getComponentFirstSlot(selectedComponentId),
                 component: clonedComponent!,
                 copyTimes: pasteManager.current.copyTimes,
               })


### PR DESCRIPTION
Now we can paste component into the components that don't have `'content'` slot.