### PR TITLE
fix(shared): use default value instead of  undefined when generate default value from spec

### DIFF
--- a/packages/shared/__tests__/spec.spec.ts
+++ b/packages/shared/__tests__/spec.spec.ts
@@ -17,14 +17,9 @@ describe('generateDefaultValueFromSpec function', () => {
     const type = Type.Number();
     expect(generateDefaultValueFromSpec(type)).toEqual(0);
   });
-  // Type.Optional can only be judged by the modifier feature provided by the typebox,
-  // but this would break the consistency of the function,
-  // and it doesn't seem to make much sense to deal with non-object optional alone like Type.Optional(Type.String())
-  // Therefore it is possible to determine whether an object's property is optional using spec.required,
-  // and if the property is within Type.Object is optional then it is not required.
-  it('can parse optional', () => {
+  it('can parse optional and the value is the default value of its type', () => {
     const type = Type.Optional(Type.Object({ str: Type.Optional(Type.String()) }));
-    expect(generateDefaultValueFromSpec(type)).toEqual({ str: undefined });
+    expect(generateDefaultValueFromSpec(type)).toEqual({ str: '' });
   });
   it('can parse object', () => {
     const type = Type.Object({

--- a/packages/shared/src/utils/spec.ts
+++ b/packages/shared/src/utils/spec.ts
@@ -31,7 +31,6 @@ function getArray(items: JSONSchema7Definition[]): JSONSchema7Type[] {
 
 function getObject(spec: JSONSchema7): JSONSchema7Object {
   const obj: JSONSchema7Object = {};
-  const requiredKeys = spec.required;
 
   if (spec.allOf && spec.allOf.length > 0) {
     return (getArray(spec.allOf) as JSONSchema7Object[]).reduce((prev, cur) => {
@@ -40,15 +39,14 @@ function getObject(spec: JSONSchema7): JSONSchema7Object {
     }, obj);
   }
 
-  requiredKeys &&
-    requiredKeys.forEach(key => {
-      const subSpec = spec.properties?.[key];
-      if (typeof subSpec === 'boolean') {
-        obj[key] = null;
-      } else if (subSpec) {
-        obj[key] = generateDefaultValueFromSpec(subSpec);
-      }
-    });
+  for (const key in spec.properties) {
+    const subSpec = spec.properties?.[key];
+    if (typeof subSpec === 'boolean') {
+      obj[key] = null;
+    } else if (subSpec) {
+      obj[key] = generateDefaultValueFromSpec(subSpec);
+    }
+  }
   return obj;
 }
 


### PR DESCRIPTION
# Problem
The optional properties' field of newly created component/trait does not show in form. For example, the hidden trait has a `visually` property and it does not show.
![截屏2022-07-22 下午6 16 50](https://user-images.githubusercontent.com/12260952/180419238-725f829a-2c39-43f0-9f7d-961f7c078f6a.png)


This is because the form is rendered from the `defaultValue` generated from spec. And the `generateDefaultValueFromSpec` function will not generate value if a property is optional. 

# Solution

So I changed the logic of `generateDefaultValueFromSpec`. It will generate default value for optional property now.