### PR TITLE
fix(traitForm): trait form will crash if the trait has a property that is not in its spec

### DIFF
--- a/packages/editor/src/components/ComponentForm/GeneralTraitFormList/GeneralTraitForm.tsx
+++ b/packages/editor/src/components/ComponentForm/GeneralTraitFormList/GeneralTraitForm.tsx
@@ -3,7 +3,6 @@ import { ComponentSchema, TraitSchema } from '@sunmao-ui/core';
 import { HStack, IconButton, VStack } from '@chakra-ui/react';
 import { generateDefaultValueFromSpec } from '@sunmao-ui/shared';
 import { CloseIcon } from '@chakra-ui/icons';
-import { TSchema } from '@sinclair/typebox';
 import { formWrapperCSS } from '../style';
 import { EditorServices } from '../../../types';
 import { SpecWidget } from '@sunmao-ui/editor-sdk';
@@ -28,7 +27,10 @@ export const GeneralTraitForm: React.FC<Props> = props => {
   );
   const fields = Object.keys(properties || []).map((key: string) => {
     const value = trait.properties[key];
-    const propertySpec = (tImpl.spec.properties as TSchema).properties?.[key];
+    const propertySpec = tImpl.spec.properties.properties?.[key];
+
+    if (!propertySpec) return undefined;
+
     const onChange = (newValue: any) => {
       const operation = genOperation(registry, 'modifyTraitProperty', {
         componentId: component.id,
@@ -41,15 +43,14 @@ export const GeneralTraitForm: React.FC<Props> = props => {
       eventBus.send('operation', operation);
     };
 
+    const specObj = propertySpec === true ? {} : propertySpec;
+
     return (
       <SpecWidget
         key={key}
         level={1}
         path={[key]}
-        spec={{
-          ...propertySpec,
-          title: propertySpec.title || key,
-        }}
+        spec={{ ...specObj, title: specObj.title || key }}
         value={value}
         services={services}
         component={component}


### PR DESCRIPTION
The trait form fields are generated from trait's properties, so if there is a property which is not in its spec, this field spec will be `undefined`, and the form will crash.

reproduce schema
```
{
  "version": "sunmao/v1",
  "kind": "Application",
  "metadata": {
    "name": "some App"
  },
  "spec": {
    "components": [
      {
        "id": "state0",
        "type": "core/v1/dummy",
        "properties": {},
        "traits": [
          {
            "type": "core/v1/state",
            "properties": {
              "key": "value",
              "initialValue": "hahaha",
              "value": ""
            }
          }
        ]
      }
    ]
  }
}
```