### PR TITLE
use the new data path to pass slot props and fallback elements

### DIFF
--- a/packages/arco-lib/src/components/Table/Table.tsx
+++ b/packages/arco-lib/src/components/Table/Table.tsx
@@ -19,6 +19,7 @@ import {
   ModuleRenderer,
   implementRuntimeComponent,
   ImplWrapper,
+  formatSlotKey,
 } from '@sunmao-ui/runtime';
 import { Type, Static } from '@sinclair/typebox';
 import { ResizableTitle } from './ResizableTitle';
@@ -178,6 +179,7 @@ export const Table = implementRuntimeComponent({
     customStyle,
     services,
     component,
+    slotsElements,
   } = props;
 
   const ref = useRef<TableInstance | null>(null);
@@ -418,6 +420,14 @@ export const Table = implementRuntimeComponent({
                 id: `${component.id}_${childSchema.id}_${index}`,
               };
 
+              /**
+               * FIXME: temporary hack
+               */
+              slotsElements.content?.({
+                [LIST_ITEM_EXP]: record,
+                [LIST_ITEM_INDEX_EXP]: index,
+              });
+
               colItem = (
                 <ImplWrapper
                   key={_childrenSchema.id}
@@ -427,9 +437,9 @@ export const Table = implementRuntimeComponent({
                   childrenMap={{}}
                   isInModule
                   evalListItem
-                  slotProps={{
-                    [LIST_ITEM_EXP]: record,
-                    [LIST_ITEM_INDEX_EXP]: index,
+                  slotContext={{
+                    renderSet: new Set(),
+                    slotKey: formatSlotKey(_childrenSchema.id, 'td', `td_${index}`),
                   }}
                 />
               );

--- a/packages/chakra-ui-lib/src/components/Table/Table.tsx
+++ b/packages/chakra-ui-lib/src/components/Table/Table.tsx
@@ -34,6 +34,7 @@ export const TableImpl = implementTable(
     services,
     app,
     elementRef,
+    slotsElements,
   }) => {
     const [selectedItem, setSelectedItem] = useState<Record<string, any> | undefined>();
     const [selectedItems, setSelectedItems] = useState<Array<Record<string, any>>>([]);
@@ -196,6 +197,7 @@ export const TableImpl = implementTable(
                       column={column}
                       services={services}
                       app={app}
+                      slotsElements={slotsElements}
                     />
                   ))}
                 </Tr>

--- a/packages/chakra-ui-lib/src/components/Table/TableTd.tsx
+++ b/packages/chakra-ui-lib/src/components/Table/TableTd.tsx
@@ -5,7 +5,7 @@ import {
   PropsBeforeEvaled,
 } from '@sunmao-ui/core';
 import { Static } from '@sinclair/typebox';
-import { ColumnSpec, ColumnsPropertySpec } from './TableTypes';
+import { ColumnSpec, ColumnsPropertySpec, ContentSlotPropsSpec } from './TableTypes';
 import { Button, Link, Td, Text } from '@chakra-ui/react';
 import {
   LIST_ITEM_EXP,
@@ -14,6 +14,8 @@ import {
   UIServices,
   ExpressionError,
   ImplWrapper,
+  SlotsElements,
+  formatSlotKey,
 } from '@sunmao-ui/runtime';
 
 export const TableTd: React.FC<{
@@ -25,9 +27,23 @@ export const TableTd: React.FC<{
   services: UIServices;
   component: RuntimeComponentSchema;
   app: RuntimeApplication;
+  slotsElements: SlotsElements<{
+    content: {
+      slotProps: typeof ContentSlotPropsSpec;
+    };
+  }>;
 }> = props => {
-  const { item, index, component, column, rawColumns, onClickItem, services, app } =
-    props;
+  const {
+    item,
+    index,
+    component,
+    column,
+    rawColumns,
+    onClickItem,
+    services,
+    app,
+    slotsElements,
+  } = props;
   const evalOptions = {
     evalListItem: true,
     scopeObject: {
@@ -118,6 +134,14 @@ export const TableTd: React.FC<{
         id: `${component.id}_${childSchema.id}_${index}`,
       };
 
+      /**
+       * FIXME: temporary hack
+       */
+      slotsElements.content?.({
+        [LIST_ITEM_EXP]: item,
+        [LIST_ITEM_INDEX_EXP]: index,
+      });
+
       content = (
         <ImplWrapper
           key={_childrenSchema.id}
@@ -127,9 +151,9 @@ export const TableTd: React.FC<{
           childrenMap={{}}
           isInModule
           evalListItem
-          slotProps={{
-            [LIST_ITEM_EXP]: item,
-            [LIST_ITEM_INDEX_EXP]: index,
+          slotContext={{
+            renderSet: new Set(),
+            slotKey: formatSlotKey(_childrenSchema.id, 'td', `td_${index}`),
           }}
         />
       );

--- a/packages/chakra-ui-lib/src/components/Table/TableTypes.ts
+++ b/packages/chakra-ui-lib/src/components/Table/TableTypes.ts
@@ -1,5 +1,10 @@
 import { Type } from '@sinclair/typebox';
-import { ModuleRenderSpec, EventCallBackHandlerSpec } from '@sunmao-ui/shared';
+import {
+  ModuleRenderSpec,
+  EventCallBackHandlerSpec,
+  LIST_ITEM_EXP,
+  LIST_ITEM_INDEX_EXP,
+} from '@sunmao-ui/shared';
 import { BASIC, APPEARANCE, BEHAVIOR } from '../constants/category';
 
 export const MajorKeyPropertySpec = Type.String({
@@ -104,4 +109,9 @@ export const IsMultiSelectPropertySpec = Type.Boolean({
 export const TableStateSpec = Type.Object({
   selectedItem: Type.Optional(Type.Object({})),
   selectedItems: Type.Array(Type.Object({})),
+});
+
+export const ContentSlotPropsSpec = Type.Object({
+  [LIST_ITEM_EXP]: Type.Any(),
+  [LIST_ITEM_INDEX_EXP]: Type.Number(),
 });

--- a/packages/chakra-ui-lib/src/components/Table/spec.ts
+++ b/packages/chakra-ui-lib/src/components/Table/spec.ts
@@ -1,9 +1,5 @@
 import { Type } from '@sinclair/typebox';
-import {
-  implementRuntimeComponent,
-  LIST_ITEM_EXP,
-  LIST_ITEM_INDEX_EXP,
-} from '@sunmao-ui/runtime';
+import { implementRuntimeComponent } from '@sunmao-ui/runtime';
 import {
   ColumnsPropertySpec,
   DataPropertySpec,
@@ -12,6 +8,7 @@ import {
   TableStateSpec,
   TableSizePropertySpec,
   IsMultiSelectPropertySpec,
+  ContentSlotPropsSpec,
 } from './TableTypes';
 
 const PropsSpec = Type.Object({
@@ -62,10 +59,7 @@ export const implementTable = implementRuntimeComponent({
     methods: {},
     slots: {
       content: {
-        slotProps: Type.Object({
-          [LIST_ITEM_EXP]: Type.Any(),
-          [LIST_ITEM_INDEX_EXP]: Type.Number(),
-        }),
+        slotProps: ContentSlotPropsSpec,
       },
     },
     styleSlots: [],

--- a/packages/chakra-ui-lib/src/components/Tabs.tsx
+++ b/packages/chakra-ui-lib/src/components/Tabs.tsx
@@ -101,7 +101,7 @@ export default implementRuntimeComponent({
                 ${customStyle?.tabContent}
               `}
             >
-              {slotsElements?.content?.({ tabIndex: idx }, placeholder)}
+              {slotsElements?.content?.({ tabIndex: idx }, placeholder, `content_${idx}`)}
             </TabPanel>
           );
         })}

--- a/packages/runtime/__tests__/testLib/Tabs.tsx
+++ b/packages/runtime/__tests__/testLib/Tabs.tsx
@@ -71,7 +71,9 @@ export default implementRuntimeComponent({
         </div>
         <div className="panels">
           {tabNames.map((n, idx) => (
-            <div key={n}>{slotsElements?.content?.({ tabIndex: idx })}</div>
+            <div key={n}>
+              {slotsElements?.content?.({ tabIndex: idx }, undefined, `content_${idx}`)}
+            </div>
           ))}
         </div>
       </div>

--- a/packages/runtime/src/components/_internal/ImplWrapper/ImplWrapper.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper/ImplWrapper.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { ImplWrapperProps } from '../../../types';
 import { shallowCompare } from '@sunmao-ui/shared';
 import { UnmountImplWrapper } from './UnmountImplWrapper';
-import { isEqual } from 'lodash';
 
 export const ImplWrapper = React.memo<ImplWrapperProps>(
   UnmountImplWrapper,
@@ -18,12 +17,6 @@ export const ImplWrapper = React.memo<ImplWrapperProps>(
     } else if (prevChildren === nextChildren) {
       isComponentEqual = true;
     }
-    return (
-      isComponentEqual &&
-      prevComponent === nextComponent &&
-      // TODO: keep ImplWrapper memorized and get slot props from store
-      shallowCompare(prevProps.slotProps, nextProps.slotProps) &&
-      isEqual(prevProps.slotContext, nextProps.slotContext)
-    );
+    return isComponentEqual && prevComponent === nextComponent;
   }
 );

--- a/packages/runtime/src/components/_internal/ImplWrapper/ImplWrapperMain.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper/ImplWrapperMain.tsx
@@ -11,8 +11,9 @@ import { initStateAndMethod } from '../../../utils/initStateAndMethod';
 
 export const ImplWrapperMain = React.forwardRef<HTMLDivElement, ImplWrapperProps>(
   function ImplWrapperMain(props, ref) {
-    const { component: c, children, evalListItem, slotProps } = props;
+    const { component: c, children, evalListItem, slotContext } = props;
     const { registry, stateManager } = props.services;
+    const slotKey = slotContext?.slotKey || '';
 
     const Impl = registry.getComponent(c.parsedType.version, c.parsedType.name).impl;
 
@@ -36,7 +37,7 @@ export const ImplWrapperMain = React.forwardRef<HTMLDivElement, ImplWrapperProps
           t,
           stateManager.deepEval(t.properties, {
             evalListItem,
-            scopeObject: { $slot: slotProps },
+            slotKey,
             fallbackWhenError: () => undefined,
           })
         )
@@ -67,7 +68,7 @@ export const ImplWrapperMain = React.forwardRef<HTMLDivElement, ImplWrapperProps
           },
           {
             evalListItem,
-            scopeObject: { $slot: slotProps },
+            slotKey,
             fallbackWhenError: () => undefined,
           }
         );
@@ -78,7 +79,7 @@ export const ImplWrapperMain = React.forwardRef<HTMLDivElement, ImplWrapperProps
       // because mergeState will be called during the first render of component, and state will change
       setTraitResults(c.traits.map((trait, i) => executeTrait(trait, properties[i])));
       return () => stops.forEach(s => s());
-    }, [c.id, c.traits, executeTrait, stateManager, slotProps, evalListItem]);
+    }, [c.id, c.traits, executeTrait, stateManager, evalListItem, slotKey]);
 
     // reduce traitResults
     const propsFromTraits: TraitResult<
@@ -112,7 +113,7 @@ export const ImplWrapperMain = React.forwardRef<HTMLDivElement, ImplWrapperProps
         stateManager.deepEval(c.properties, {
           fallbackWhenError: () => undefined,
           evalListItem,
-          scopeObject: { $slot: slotProps },
+          slotKey,
         }),
         propsFromTraits
       );
@@ -127,14 +128,14 @@ export const ImplWrapperMain = React.forwardRef<HTMLDivElement, ImplWrapperProps
         {
           evalListItem,
           fallbackWhenError: () => undefined,
-          scopeObject: { $slot: slotProps },
+          slotKey,
         }
       );
       // must keep this line, reason is the same as above
       setEvaledComponentProperties({ ...result });
 
       return stop;
-    }, [c.properties, stateManager, slotProps, evalListItem]);
+    }, [c.properties, stateManager, evalListItem, slotKey]);
 
     useEffect(() => {
       const clearFunctions = propsFromTraits?.componentDidMount?.map(e => e());
@@ -167,7 +168,7 @@ export const ImplWrapperMain = React.forwardRef<HTMLDivElement, ImplWrapperProps
       <Impl
         ref={ref}
         key={c.id}
-        {...omit(props, ['slotProps', 'slotContext'])}
+        {...omit(props, ['slotContext'])}
         {...mergedProps}
         slotsElements={slotElements}
         mergeState={mergeState}

--- a/packages/runtime/src/components/_internal/ImplWrapper/SlotReciver.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper/SlotReciver.tsx
@@ -1,0 +1,64 @@
+/**
+ * The slot receiver is a magic hole of sunmao's runtime.
+ * In sunmao, we support pass props and fallback elements to a slot.
+ * But if we pass them as React component's props,
+ * it will cause re-render since most of them could not use a shallow equal checker.
+ *
+ * Also, in sunmao's runtime, we are not using a traditional React render mechanism.
+ * Instead, we keep most of the components not be rendered and only subscribe to related state updates.
+ *
+ * To continue with our design,
+ * we need a way to render slot's fallback elements without passing the elements as props.
+ * This is where the slot receiver comes.
+ * It contains a map and an event emitter, when a slot need render,
+ * it will attach the fallback elements to the map and send a signal via the emitter.
+ * When the Receiver component receive a signal, it will force render the fallback elements.
+ */
+import React, { useEffect, useState, useRef } from 'react';
+import mitt from 'mitt';
+
+class SlotReceiver {
+  fallbacks: Partial<Record<string, React.ReactNode>> = {};
+  emitter = mitt<Record<string, React.ReactNode>>();
+
+  constructor() {
+    this.emitter.on('*', (slotKey: string, c: React.ReactNode) => {
+      // undefined means no fallback has been received yet
+      // null means the Receiver component start to hanle the events
+      if (this.fallbacks[slotKey] === undefined) {
+        this.fallbacks[slotKey] = c;
+      }
+    });
+  }
+}
+
+export const slotReceiver = new SlotReceiver();
+
+export const Receiver: React.FC<{ slotKey?: string }> = ({ slotKey = '' }) => {
+  const [, setForce] = useState(0);
+  const cRef = useRef<React.ReactNode>(slotReceiver.fallbacks[slotKey] || null);
+  useEffect(() => {
+    if (!slotKey) {
+      return;
+    }
+    const handler = (c: React.ReactNode) => {
+      if (slotReceiver.fallbacks[slotKey]) {
+        // release memory
+        slotReceiver.fallbacks[slotKey] = null;
+      }
+      cRef.current = c;
+      /**
+       * the event emitter fired during render process
+       * defer the setState to avoid React warning
+       */
+      setTimeout(() => {
+        setForce(prev => prev + 1);
+      }, 0);
+    };
+    slotReceiver.emitter.on(slotKey, handler);
+    return () => {
+      slotReceiver.emitter.off(slotKey, handler);
+    };
+  }, [slotKey]);
+  return <>{cRef.current}</>;
+};

--- a/packages/runtime/src/components/_internal/ImplWrapper/UnmountImplWrapper.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper/UnmountImplWrapper.tsx
@@ -5,6 +5,7 @@ import { useRuntimeFunctions } from './hooks/useRuntimeFunctions';
 import { initSingleComponentState } from '../../../utils/initStateAndMethod';
 import { ImplWrapperProps, TraitResult } from '../../../types';
 import { watch } from '../../..';
+import { Receiver } from './SlotReciver';
 
 export const UnmountImplWrapper = React.forwardRef<HTMLDivElement, ImplWrapperProps>(
   function UnmountImplWrapper(props, ref) {
@@ -13,6 +14,8 @@ export const UnmountImplWrapper = React.forwardRef<HTMLDivElement, ImplWrapperPr
     const { executeTrait } = useRuntimeFunctions(props);
     const renderCount = useRef(0);
     renderCount.current++;
+
+    const slotKey = slotContext?.slotKey || '';
 
     const unmountTraits = useMemo(
       () =>
@@ -26,7 +29,7 @@ export const UnmountImplWrapper = React.forwardRef<HTMLDivElement, ImplWrapperPr
       const results: TraitResult<ReadonlyArray<string>, ReadonlyArray<string>>[] =
         unmountTraits.map(t => {
           const properties = stateManager.deepEval(t.properties, {
-            scopeObject: { $slot: props.slotProps },
+            slotKey,
           });
           return executeTrait(t, properties);
         });
@@ -69,7 +72,7 @@ export const UnmountImplWrapper = React.forwardRef<HTMLDivElement, ImplWrapperPr
             t.properties,
             newValue => traitChangeCallback(t, newValue.result),
             {
-              scopeObject: { $slot: props.slotProps },
+              slotKey,
             }
           );
           traitChangeCallback(t, result);
@@ -79,14 +82,7 @@ export const UnmountImplWrapper = React.forwardRef<HTMLDivElement, ImplWrapperPr
       return () => {
         stops.forEach(stop => stop());
       };
-    }, [
-      c,
-      executeTrait,
-      unmountTraits,
-      stateManager,
-      traitChangeCallback,
-      props.slotProps,
-    ]);
+    }, [c, executeTrait, unmountTraits, stateManager, traitChangeCallback, slotKey]);
 
     // If a component is unmount, its state would be removed.
     // So if it mount again, we should init its state again.
@@ -97,7 +93,7 @@ export const UnmountImplWrapper = React.forwardRef<HTMLDivElement, ImplWrapperPr
     if (isHidden && slotContext) {
       slotContext.renderSet.delete(c.id);
       if (slotContext.renderSet.size === 0) {
-        return <>{slotContext.fallback}</>;
+        return <Receiver slotKey={slotContext.slotKey} />;
       }
     }
     return !isHidden ? <ImplWrapperMain {...props} ref={ref} /> : null;

--- a/packages/runtime/src/components/_internal/ImplWrapper/UnmountImplWrapper.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper/UnmountImplWrapper.tsx
@@ -5,7 +5,7 @@ import { useRuntimeFunctions } from './hooks/useRuntimeFunctions';
 import { initSingleComponentState } from '../../../utils/initStateAndMethod';
 import { ImplWrapperProps, TraitResult } from '../../../types';
 import { watch } from '../../..';
-import { Receiver } from './SlotReciver';
+import { Receiver } from '../../../services/SlotReciver';
 
 export const UnmountImplWrapper = React.forwardRef<HTMLDivElement, ImplWrapperProps>(
   function UnmountImplWrapper(props, ref) {
@@ -93,7 +93,9 @@ export const UnmountImplWrapper = React.forwardRef<HTMLDivElement, ImplWrapperPr
     if (isHidden && slotContext) {
       slotContext.renderSet.delete(c.id);
       if (slotContext.renderSet.size === 0) {
-        return <Receiver slotKey={slotContext.slotKey} />;
+        return (
+          <Receiver slotKey={slotContext.slotKey} slotReceiver={services.slotReceiver} />
+        );
       }
     }
     return !isHidden ? <ImplWrapperMain {...props} ref={ref} /> : null;

--- a/packages/runtime/src/components/_internal/ImplWrapper/hooks/useRuntimeFunctions.ts
+++ b/packages/runtime/src/components/_internal/ImplWrapper/hooks/useRuntimeFunctions.ts
@@ -5,8 +5,9 @@ import { merge } from 'lodash';
 import { HandlerMap } from '../../../../services/handler';
 
 export function useRuntimeFunctions(props: ImplWrapperProps) {
-  const { component: c, services, slotProps, evalListItem } = props;
+  const { component: c, services, slotContext, evalListItem } = props;
   const { stateManager, registry, globalHandlerMap } = services;
+  const slotKey = slotContext?.slotKey || '';
 
   const mergeState = useCallback(
     (partial: any) => {
@@ -35,11 +36,11 @@ export function useRuntimeFunctions(props: ImplWrapperProps) {
         mergeState,
         subscribeMethods,
         services,
-        slotProps,
+        slotKey,
         evalListItem,
       });
     },
-    [c.id, evalListItem, mergeState, registry, services, slotProps, subscribeMethods]
+    [c.id, evalListItem, mergeState, registry, services, slotKey, subscribeMethods]
   );
   return {
     mergeState,

--- a/packages/runtime/src/components/_internal/ImplWrapper/hooks/useSlotChildren.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper/hooks/useSlotChildren.tsx
@@ -3,7 +3,6 @@ import { SlotSpec } from '@sunmao-ui/core';
 import { ImplWrapperProps, SlotsElements } from '../../../../types';
 import { ImplWrapper } from '../ImplWrapper';
 import { shallowCompare } from '@sunmao-ui/shared';
-import { slotReceiver } from '../SlotReciver';
 
 export function formatSlotKey(componentId: string, slot: string, key: string): string {
   /**
@@ -45,7 +44,7 @@ export function getSlotElements(
           slotContext,
         })
       );
-      slotReceiver.emitter.emit(slotKey, slotFallback);
+      services.slotReceiver.emitter.emit(slotKey, slotFallback);
       return children;
     };
   }

--- a/packages/runtime/src/components/_internal/ImplWrapper/hooks/useSlotChildren.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper/hooks/useSlotChildren.tsx
@@ -25,6 +25,10 @@ export function getSlotElements(
        * TODO: better naming strategy to avoid of conflicts
        */
       const slotKey = `${c.id}_${slot}${key ? `_${key}` : ''}`;
+      /**
+       * The shallow compare is just a heuristic optimization,
+       * feel free to improve it.
+       */
       if (!shallowCompare(services.stateManager.slotStore[slotKey], slotProps)) {
         services.stateManager.slotStore[slotKey] = slotProps;
       }

--- a/packages/runtime/src/components/_internal/ImplWrapper/hooks/useSlotChildren.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper/hooks/useSlotChildren.tsx
@@ -2,34 +2,42 @@ import React from 'react';
 import { SlotSpec } from '@sunmao-ui/core';
 import { ImplWrapperProps, SlotsElements } from '../../../../types';
 import { ImplWrapper } from '../ImplWrapper';
+import { shallowCompare } from '@sunmao-ui/shared';
+import { slotReceiver } from '../SlotReciver';
 
 export function getSlotElements(
   props: ImplWrapperProps & { children?: React.ReactNode }
 ): SlotsElements<Record<string, SlotSpec>> {
-  const { component: c, childrenMap } = props;
+  const { component: c, childrenMap, services } = props;
 
   if (!childrenMap[c.id]) {
     return {};
   }
   const slotElements: SlotsElements<Record<string, SlotSpec>> = {};
+
   for (const slot in childrenMap[c.id]) {
     const slotChildren = childrenMap[c.id][slot].map(child => {
       return <ImplWrapper key={child.id} {...props} component={child} />;
     });
 
-    slotElements[slot] = function getSlot(slotProps, slotFallback) {
+    slotElements[slot] = function getSlot(slotProps, slotFallback, key) {
+      /**
+       * TODO: better naming strategy to avoid of conflicts
+       */
+      const slotKey = `${c.id}_${slot}${key ? `_${key}` : ''}`;
+      if (!shallowCompare(services.stateManager.slotStore[slotKey], slotProps)) {
+        services.stateManager.slotStore[slotKey] = slotProps;
+      }
       const slotContext = {
         renderSet: new Set(childrenMap[c.id][slot].map(child => child.id)),
-        parentId: c.id,
-        slotProps: JSON.stringify(slotProps),
-        fallback: slotFallback,
+        slotKey,
       };
       const children = slotChildren.map(child =>
         React.cloneElement(child, {
-          slotProps,
           slotContext,
         })
       );
+      slotReceiver.emitter.emit(slotKey, slotFallback);
       return children;
     };
   }

--- a/packages/runtime/src/components/_internal/ImplWrapper/hooks/useSlotChildren.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper/hooks/useSlotChildren.tsx
@@ -5,6 +5,13 @@ import { ImplWrapper } from '../ImplWrapper';
 import { shallowCompare } from '@sunmao-ui/shared';
 import { slotReceiver } from '../SlotReciver';
 
+export function formatSlotKey(componentId: string, slot: string, key: string): string {
+  /**
+   * TODO: better naming strategy to avoid of conflicts
+   */
+  return `${componentId}_${slot}${key ? `_${key}` : ''}`;
+}
+
 export function getSlotElements(
   props: ImplWrapperProps & { children?: React.ReactNode }
 ): SlotsElements<Record<string, SlotSpec>> {
@@ -21,10 +28,7 @@ export function getSlotElements(
     });
 
     slotElements[slot] = function getSlot(slotProps, slotFallback, key) {
-      /**
-       * TODO: better naming strategy to avoid of conflicts
-       */
-      const slotKey = `${c.id}_${slot}${key ? `_${key}` : ''}`;
+      const slotKey = formatSlotKey(c.id, slot, key!);
       /**
        * The shallow compare is just a heuristic optimization,
        * feel free to improve it.

--- a/packages/runtime/src/components/core/List.tsx
+++ b/packages/runtime/src/components/core/List.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/css';
 import { LIST_ITEM_EXP, LIST_ITEM_INDEX_EXP } from '../../constants';
 import { implementRuntimeComponent } from '../../utils/buildKit';
 import { ImplWrapper } from '../_internal/ImplWrapper';
+import { formatSlotKey } from '../_internal/ImplWrapper/hooks/useSlotChildren';
 
 const PropsSpec = Type.Object({
   listData: Type.Array(Type.Record(Type.String(), Type.String()), {
@@ -42,7 +43,7 @@ export default implementRuntimeComponent({
     styleSlots: ['content'],
     events: [],
   },
-})(({ listData, component, app, services, customStyle, elementRef }) => {
+})(({ listData, component, app, services, customStyle, elementRef, slotsElements }) => {
   if (!listData) {
     return null;
   }
@@ -74,6 +75,18 @@ export default implementRuntimeComponent({
       };
     });
 
+    /**
+     * FIXME: temporary hack
+     */
+    slotsElements.content?.(
+      {
+        [LIST_ITEM_EXP]: listItem,
+        [LIST_ITEM_INDEX_EXP]: i,
+      },
+      undefined,
+      `content_${i}`
+    );
+
     const childrenEles = _childrenSchema.map(child => {
       return (
         <ImplWrapper
@@ -84,9 +97,9 @@ export default implementRuntimeComponent({
           childrenMap={{}}
           isInModule
           evalListItem
-          slotProps={{
-            [LIST_ITEM_EXP]: listItem,
-            [LIST_ITEM_INDEX_EXP]: i,
+          slotContext={{
+            renderSet: new Set(),
+            slotKey: formatSlotKey(component.id, 'content', `content_${i}`),
           }}
         />
       );

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -94,6 +94,7 @@ export {
   StringUnion,
   generateDefaultValueFromSpec,
 } from '@sunmao-ui/shared';
+export { formatSlotKey } from './components/_internal/ImplWrapper/hooks/useSlotChildren';
 
 // TODO: check this export
 export { watch } from './utils/watchReactivity';

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -7,6 +7,7 @@ import { UtilMethodManager } from './services/UtilMethodManager';
 import { AppHooks } from './types';
 import { enableES5, setAutoFreeze } from 'immer';
 import './style.css';
+import { initSlotReceiver } from './services/SlotReciver';
 
 // immer would make some errors when read the states, so we do these to avoid it temporarily
 // ref: https://github.com/immerjs/immer/issues/916
@@ -26,12 +27,14 @@ export function initSunmaoUI(props: SunmaoUIRuntimeProps = {}) {
   const apiService = initApiService();
   const utilMethodManager = new UtilMethodManager(apiService);
   const eleMap = new Map<string, HTMLElement>();
+  const slotReceiver = initSlotReceiver();
   const registry = initRegistry(
     {
       stateManager,
       globalHandlerMap,
       apiService,
       eleMap,
+      slotReceiver,
     },
     utilMethodManager
   );
@@ -48,6 +51,7 @@ export function initSunmaoUI(props: SunmaoUIRuntimeProps = {}) {
         globalHandlerMap,
         apiService,
         eleMap,
+        slotReceiver,
       },
       props.hooks,
       props.isInEditor

--- a/packages/runtime/src/services/SlotReciver.tsx
+++ b/packages/runtime/src/services/SlotReciver.tsx
@@ -17,7 +17,7 @@
 import React, { useEffect, useState, useRef } from 'react';
 import mitt from 'mitt';
 
-class SlotReceiver {
+export class SlotReceiver {
   fallbacks: Partial<Record<string, React.ReactNode>> = {};
   emitter = mitt<Record<string, React.ReactNode>>();
 
@@ -32,9 +32,14 @@ class SlotReceiver {
   }
 }
 
-export const slotReceiver = new SlotReceiver();
+export function initSlotReceiver() {
+  return new SlotReceiver();
+}
 
-export const Receiver: React.FC<{ slotKey?: string }> = ({ slotKey = '' }) => {
+export const Receiver: React.FC<{ slotKey?: string; slotReceiver: SlotReceiver }> = ({
+  slotKey = '',
+  slotReceiver,
+}) => {
   const [, setForce] = useState(0);
   const cRef = useRef<React.ReactNode>(slotReceiver.fallbacks[slotKey] || null);
   useEffect(() => {
@@ -59,6 +64,8 @@ export const Receiver: React.FC<{ slotKey?: string }> = ({ slotKey = '' }) => {
     return () => {
       slotReceiver.emitter.off(slotKey, handler);
     };
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [slotKey]);
   return <>{cRef.current}</>;
 };

--- a/packages/runtime/src/services/StateManager.ts
+++ b/packages/runtime/src/services/StateManager.ts
@@ -22,6 +22,7 @@ type EvalOptions = {
   fallbackWhenError?: (exp: string) => any;
   // when ignoreEvalError is true, the eval process will continue after error happens in nests expression.
   ignoreEvalError?: boolean;
+  slotKey?: string;
 };
 
 type EvaledResult<T> = T extends string ? unknown : PropsAfterEvaled<Exclude<T, string>>;
@@ -42,6 +43,7 @@ export type StateManagerInterface = InstanceType<typeof StateManager>;
 
 export class StateManager {
   store = reactive<Record<string, any>>({});
+  slotStore = reactive<Record<string, any>>({});
 
   dependencies: Record<string, unknown>;
 
@@ -155,6 +157,20 @@ export class StateManager {
     value: T,
     options: EvalOptions = {}
   ): EvaledResult<T> {
+    const store = this.slotStore;
+    const redirector = new Proxy(
+      {},
+      {
+        get(_, prop) {
+          return options.slotKey ? store[options.slotKey][prop] : undefined;
+        },
+      }
+    );
+
+    options.scopeObject = {
+      ...options.scopeObject,
+      $slot: redirector,
+    };
     // just eval
     if (typeof value !== 'string') {
       return this.mapValuesDeep(value, ({ value }) => {
@@ -180,6 +196,19 @@ export class StateManager {
       ? unknown
       : PropsAfterEvaled<Exclude<T, string>>;
 
+    const store = this.slotStore;
+    const redirector = new Proxy(
+      {},
+      {
+        get(_, prop) {
+          return options.slotKey ? store[options.slotKey][prop] : undefined;
+        },
+      }
+    );
+    options.scopeObject = {
+      ...options.scopeObject,
+      $slot: redirector,
+    };
     // watch change
     if (value && typeof value === 'object') {
       let resultCache = evaluated as PropsAfterEvaled<Exclude<T, string>>;
@@ -210,11 +239,13 @@ export class StateManager {
       const stop = watch(
         () => {
           const result = this._maskedEval(value, options);
-
           return result;
         },
         newV => {
           watcher({ result: newV as EvaledResult<T> });
+        },
+        {
+          deep: true,
         }
       );
       stops.push(stop);

--- a/packages/runtime/src/traits/core/Event.tsx
+++ b/packages/runtime/src/traits/core/Event.tsx
@@ -21,14 +21,14 @@ export const generateCallback = (
   rawHandlers: string | PropsBeforeEvaled<Static<typeof CallbackSpec>>,
   index: number,
   services: UIServices,
-  slotProps?: unknown,
+  slotKey: string,
   evalListItem?: boolean
 ) => {
   const { stateManager } = services;
   const send = () => {
     // Eval before sending event to assure the handler object is evaled from the latest state.
     const evalOptions = {
-      scopeObject: { $slot: slotProps },
+      slotKey,
       evalListItem,
     };
     const evaledHandlers = stateManager.deepEval(rawHandlers, evalOptions) as Static<
@@ -73,7 +73,7 @@ export default implementRuntimeTrait({
     state: {},
   },
 })(() => {
-  return ({ trait, handlers, services, slotProps, evalListItem }) => {
+  return ({ trait, handlers, services, evalListItem, slotKey }) => {
     const callbackQueueMap: Record<string, Array<() => void>> = {};
     const rawHandlers = trait.properties.handlers;
     // setup current handlers
@@ -84,14 +84,7 @@ export default implementRuntimeTrait({
         callbackQueueMap[handler.type] = [];
       }
       callbackQueueMap[handler.type].push(
-        generateCallback(
-          handler,
-          rawHandlers,
-          Number(i),
-          services,
-          slotProps,
-          evalListItem
-        )
+        generateCallback(handler, rawHandlers, Number(i), services, slotKey, evalListItem)
       );
     }
 

--- a/packages/runtime/src/traits/core/Fetch.tsx
+++ b/packages/runtime/src/traits/core/Fetch.tsx
@@ -85,6 +85,7 @@ export default implementRuntimeTrait({
     subscribeMethods,
     componentId,
     disabled,
+    slotKey,
   }) => {
     const lazy = _lazy === undefined ? true : _lazy;
 
@@ -157,7 +158,13 @@ export default implementRuntimeTrait({
             const rawOnComplete = trait.properties.onComplete;
 
             onComplete?.forEach((_, index) => {
-              generateCallback(onComplete[index], rawOnComplete, index, services)();
+              generateCallback(
+                onComplete[index],
+                rawOnComplete,
+                index,
+                services,
+                slotKey
+              )();
             });
           } else {
             // TODO: Add FetchError class and remove console info
@@ -174,7 +181,7 @@ export default implementRuntimeTrait({
             const rawOnError = trait.properties.onError;
 
             onError?.forEach((_, index) => {
-              generateCallback(onError[index], rawOnError, index, services)();
+              generateCallback(onError[index], rawOnError, index, services, slotKey)();
             });
           }
         },
@@ -193,7 +200,7 @@ export default implementRuntimeTrait({
           const rawOnError = trait.properties.onError;
 
           onError?.forEach((_, index) => {
-            generateCallback(onError[index], rawOnError, index, services)();
+            generateCallback(onError[index], rawOnError, index, services, slotKey)();
           });
         }
       );

--- a/packages/runtime/src/types/application.ts
+++ b/packages/runtime/src/types/application.ts
@@ -2,6 +2,7 @@ import { ApiService } from '../services/apiService';
 import { GlobalHandlerMap } from '../services/handler';
 import { RegistryInterface } from '../services/Registry';
 import { StateManagerInterface } from '../services/StateManager';
+import { SlotReceiver } from '../services/SlotReciver';
 import { Application } from '@sunmao-ui/core';
 
 export type UIServices = {
@@ -10,6 +11,7 @@ export type UIServices = {
   globalHandlerMap: GlobalHandlerMap;
   apiService: ApiService;
   eleMap: Map<string, HTMLElement>;
+  slotReceiver: SlotReceiver;
 };
 
 export type ComponentParamsFromApp = {

--- a/packages/runtime/src/types/component.ts
+++ b/packages/runtime/src/types/component.ts
@@ -22,8 +22,7 @@ export type ImplWrapperProps<
   isInModule: boolean;
   app: RuntimeApplication;
   evalListItem?: boolean;
-  slotProps?: unknown;
-  slotContext?: { renderSet: Set<string>; fallback?: React.ReactNode };
+  slotContext?: { renderSet: Set<string>; slotKey?: string };
 } & ComponentParamsFromApp;
 
 export type ComponentImplProps<
@@ -77,7 +76,8 @@ type MergeState<T> = (partialState: Partial<T>) => void;
 export type SlotsElements<U extends Record<string, SlotSpec>> = {
   [K in keyof U]?: (
     props: Static<U[K]['slotProps']>,
-    fallback?: React.ReactNode
+    fallback?: React.ReactNode,
+    key?: string
   ) => React.ReactNode;
 };
 

--- a/packages/runtime/src/types/trait.ts
+++ b/packages/runtime/src/types/trait.ts
@@ -26,7 +26,7 @@ export type TraitImpl<TProperties = any> = (
       componentId: string;
       services: UIServices;
       evalListItem?: boolean;
-      slotProps?: unknown;
+      slotKey: string;
     }
 ) => TraitResult<ReadonlyArray<string>, ReadonlyArray<string>>;
 


### PR DESCRIPTION
Overview:

![image](https://user-images.githubusercontent.com/13651389/183550909-ee4c07e7-e14c-4b89-98c8-3fad9d1a1a9a.png)

The main idea of this patch is to set slot props to a reactive store instead of passing them as React props to the slot children elements. On the other hand, we put fallback elements into a Map either, to avoid of passing them as props.

## Pass slot props

Same as other state management in sunmao, the component will subscribe to the slot store to get the latest value of slot props.

Same as component id, we need a way to identify every slot prop in the store. So we add a new parameter key to the `getSlot` function, where [component id, slot name, key] will be a unique identifier.

> Currently, the PR you are reviewing only migrates several components with the new `key` parameter, but we will migrate all if the solution passes the review.

Another challenge is to subscribe to the slot store in an efficient way. Currently, we are using Vue's reactivity system, which needs to set `deep: true` to observe multiple values during effect.

By setting `deep: true`, if we write code like `const $slot = slotStore[slotKey]`, it will subscribe to all the sub-fields of this slot key because of we 'access' the property.

The solution is to implement a redirector Proxy. With the redirector, expression `$slot.a.b` will be redirect to `slotStore[slotKey].a.b`.

## Pass slot fallback elements

The slot receiver implementation is a magic hole of sunmao's runtime.

In sunmao, we support pass props and fallback elements to a slot. But if we pass them as React component's props, it will cause re-render since most of them could not use a shallow equal checker.

Also, in sunmao's runtime, we **are not using** a traditional React render mechanism. Instead, we keep most of the components not rendered and only subscribe to related state updates.

To continue with our design, we need a way to render the slot's fallback elements without passing the elements as props.

This is where the slot receiver comes. It contains a map and an event emitter, when a slot needs to render, it will attach the fallback elements to the map and send a signal via the emitter.

When the Receiver component receives a signal, it will **force render** the fallback elements.

## Benefits

With the new approach, our `ImplWrapper` becomes very clean again, which does not need to check the equality of slot props and slot context.

By introducing the `key` concept, it may solve the conflict of id in loop-render slots.

Also, I suggest unifying the previous `List` implementation with this approach, which I've done a simple demo in this patch.