### PR TITLE
fix(editor): fix a bug which will cause the mask of chakra-ui/checkbo…

### DIFF
--- a/packages/chakra-ui-lib/src/components/Checkbox.tsx
+++ b/packages/chakra-ui-lib/src/components/Checkbox.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Static, Type } from '@sinclair/typebox';
 import { Checkbox as BaseCheckbox, useCheckboxGroupContext } from '@chakra-ui/react';
 import { implementRuntimeComponent, Text, TextPropertySpec } from '@sunmao-ui/runtime';
@@ -116,7 +116,7 @@ export default implementRuntimeComponent({
     colorScheme,
     mergeState,
     customStyle,
-    elementRef,
+    getElement,
   }) => {
     const groupContext = useCheckboxGroupContext();
     let _defaultIsChecked = false;
@@ -126,6 +126,8 @@ export default implementRuntimeComponent({
       _defaultIsChecked = groupContext.value.some(val => val === value);
     }
     const [checked, setChecked] = useState(_defaultIsChecked);
+
+    const ref = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
       mergeState({ text: text.raw });
@@ -142,6 +144,12 @@ export default implementRuntimeComponent({
     useEffect(() => {
       setChecked(!!defaultIsChecked);
     }, [setChecked, defaultIsChecked]);
+
+    useEffect(() => {
+      if (getElement && ref.current) {
+        getElement(ref.current.parentElement as HTMLElement);
+      }
+    });
 
     const args: {
       colorScheme?: Static<ReturnType<typeof getColorSchemePropertySpec>>;
@@ -170,7 +178,7 @@ export default implementRuntimeComponent({
         className={css`
           ${customStyle?.content}
         `}
-        ref={elementRef}
+        ref={ref}
       >
         <Text value={text} />
       </BaseCheckbox>

--- a/packages/chakra-ui-lib/src/components/Checkbox.tsx
+++ b/packages/chakra-ui-lib/src/components/Checkbox.tsx
@@ -149,7 +149,7 @@ export default implementRuntimeComponent({
       if (getElement && ref.current) {
         getElement(ref.current.parentElement as HTMLElement);
       }
-    });
+    }, [getElement, ref]);
 
     const args: {
       colorScheme?: Static<ReturnType<typeof getColorSchemePropertySpec>>;

--- a/packages/editor/src/components/EditorMaskWrapper/EditorMaskManager.ts
+++ b/packages/editor/src/components/EditorMaskWrapper/EditorMaskManager.ts
@@ -137,10 +137,7 @@ export class EditorMaskManager {
   };
 
   private getMaskPosition(id: string) {
-    let rect = this.eleMap.get(id)?.getBoundingClientRect();
-    if (this.eleMap.get(id)?.classList.contains('chakra-checkbox__input')) {
-      rect = this.eleMap.get(id)?.parentElement?.getBoundingClientRect();
-    }
+    const rect = this.eleMap.get(id)?.getBoundingClientRect();
     if (!this.maskContainerRect || !rect) return null;
     return {
       id,
@@ -182,7 +179,7 @@ export class EditorMaskManager {
 
     // check all the parents of hoverElement, until find a sunmao component's element
     let curr = hoverElement;
-    while (!this.elementIdMap.has(curr) && !curr.classList.contains('chakra-checkbox')) {
+    while (!this.elementIdMap.has(curr)) {
       if (curr !== root && curr.parentElement) {
         curr = curr.parentElement;
       } else {
@@ -191,14 +188,7 @@ export class EditorMaskManager {
     }
 
     this.lastHoverElement = hoverElement;
-    if (curr.classList.contains('chakra-checkbox')) {
-      this.setHoverComponentId(
-        this.elementIdMap.get(curr.querySelector('.chakra-checkbox__input') as Element) ||
-          ''
-      );
-    } else {
-      this.setHoverComponentId(this.elementIdMap.get(curr) || '');
-    }
+    this.setHoverComponentId(this.elementIdMap.get(curr) || '');
   }
 
   private refreshMaskPosition() {

--- a/packages/editor/src/components/EditorMaskWrapper/EditorMaskManager.ts
+++ b/packages/editor/src/components/EditorMaskWrapper/EditorMaskManager.ts
@@ -137,7 +137,10 @@ export class EditorMaskManager {
   };
 
   private getMaskPosition(id: string) {
-    const rect = this.eleMap.get(id)?.getBoundingClientRect();
+    let rect = this.eleMap.get(id)?.getBoundingClientRect();
+    if (this.eleMap.get(id)?.classList.contains('chakra-checkbox__input')) {
+      rect = this.eleMap.get(id)?.parentElement?.getBoundingClientRect();
+    }
     if (!this.maskContainerRect || !rect) return null;
     return {
       id,
@@ -179,7 +182,7 @@ export class EditorMaskManager {
 
     // check all the parents of hoverElement, until find a sunmao component's element
     let curr = hoverElement;
-    while (!this.elementIdMap.has(curr)) {
+    while (!this.elementIdMap.has(curr) && !curr.classList.contains('chakra-checkbox')) {
       if (curr !== root && curr.parentElement) {
         curr = curr.parentElement;
       } else {
@@ -188,7 +191,14 @@ export class EditorMaskManager {
     }
 
     this.lastHoverElement = hoverElement;
-    this.setHoverComponentId(this.elementIdMap.get(curr) || '');
+    if (curr.classList.contains('chakra-checkbox')) {
+      this.setHoverComponentId(
+        this.elementIdMap.get(curr.querySelector('.chakra-checkbox__input') as Element) ||
+          ''
+      );
+    } else {
+      this.setHoverComponentId(this.elementIdMap.get(curr) || '');
+    }
   }
 
   private refreshMaskPosition() {


### PR DESCRIPTION
…x render incorrectly

Chakra-ui/Checkbox set its ref in an inner 1px * 1px input element, so the EditorMaskManager got a 1px*1px hoverComponent and selectedComponent, then render a 1px * 1px mask.
Chakra-ui/Checkbox把它ref透传到了它内部的一个input元素中，而这个元素的宽高只有1px，所以在编辑器中这个checkbox无法被hover到，且选中时渲染出来的mask也只有1px的宽高。
<img width="588" alt="image" src="https://user-images.githubusercontent.com/53017934/181741466-4b982322-bf5b-4fbe-b8c5-723a7dbcdce4.png">
![image](https://user-images.githubusercontent.com/53017934/181741605-7ed7eec9-740e-44ff-8f14-272eb6b15681.png)


This is a temporary fix, in future, i will push a feature to separate elementRef and mask, it may look like:
这是一次临时性修复，我会想把控制行为的elementRef和mask分离开来，而不是通过这样给某个组件打补丁的方式来解决这类问题。
<img width="298" alt="image" src="https://user-images.githubusercontent.com/53017934/181742410-e52b9ead-c807-412e-a9ee-538907de9c58.png">
