### PR TITLE
fix: fix clicking outside can't close the popover widget

### DIFF
--- a/packages/editor-sdk/src/components/Widgets/EventWidget.tsx
+++ b/packages/editor-sdk/src/components/Widgets/EventWidget.tsx
@@ -16,6 +16,7 @@ import {
 } from '@sunmao-ui/shared';
 import { Select as RcSelect } from '../Select';
 import { JSONSchema7Object } from 'json-schema';
+import { PREVENT_POPOVER_WIDGET_CLOSE_CLASS } from '../../constants/widget';
 
 const EventWidgetOptions = Type.Object({});
 
@@ -225,6 +226,7 @@ export const EventWidget: React.FC<WidgetProps<EventWidgetType>> = observer(prop
         bordered={false}
         onChange={onTargetComponentChange}
         placeholder="Select Target Component"
+        dropdownClassName={PREVENT_POPOVER_WIDGET_CLOSE_CLASS}
         style={{ width: '100%' }}
         value={formik.values.componentId === '' ? undefined : formik.values.componentId}
       >

--- a/packages/editor-sdk/src/components/Widgets/PopoverWidget.tsx
+++ b/packages/editor-sdk/src/components/Widgets/PopoverWidget.tsx
@@ -20,6 +20,7 @@ import { SpecWidget } from './SpecWidget';
 import { implementWidget } from '../../utils/widget';
 import { WidgetProps } from '../../types/widget';
 import { CORE_VERSION, CoreWidgetName } from '@sunmao-ui/shared';
+import { PREVENT_POPOVER_WIDGET_CLOSE_CLASS } from '../../constants/widget';
 
 type EvenType = {
   'sub-popover-close': string[];
@@ -71,10 +72,12 @@ export const PopoverWidget = React.forwardRef<
     emitter.emit('other-popover-close', path);
   }, [path]);
   const handleClickTrigger = useCallback(event => {
+    event.stopPropagation();
     event.nativeEvent.stopImmediatePropagation();
   }, []);
   const handleClickContent = useCallback(
     event => {
+      event.stopPropagation();
       event.nativeEvent.stopImmediatePropagation();
       emitter.emit('sub-popover-close', path);
     },
@@ -117,14 +120,22 @@ export const PopoverWidget = React.forwardRef<
     };
   }, [handlerCloseByParent, handlerCloseByOther]);
   useEffect(() => {
-    const handleClickOutside = () => {
+    const handleClickOutside = (event: any) => {
+      if (
+        event.path.some((node: Element) =>
+          [...(node.classList?.values() || [])].includes(
+            PREVENT_POPOVER_WIDGET_CLOSE_CLASS
+          )
+        )
+      )
+        return;
       setIsOpen(false);
     };
 
-    document.addEventListener('click', handleClickOutside);
+    document.addEventListener('click', handleClickOutside, true);
 
     return () => {
-      document.removeEventListener('click', handleClickOutside);
+      document.removeEventListener('click', handleClickOutside, true);
     };
   }, []);
 
@@ -155,7 +166,10 @@ export const PopoverWidget = React.forwardRef<
         )}
       </PopoverTrigger>
       <Portal>
-        <PopoverContent onClick={handleClickContent}>
+        <PopoverContent
+          className={PREVENT_POPOVER_WIDGET_CLOSE_CLASS}
+          onClick={handleClickContent}
+        >
           <PopoverArrow />
           <PopoverBody maxHeight="400px" overflow="auto">
             {isInit ? (

--- a/packages/editor-sdk/src/constants/index.ts
+++ b/packages/editor-sdk/src/constants/index.ts
@@ -1,5 +1,6 @@
 export {
   PRESET_PROPERTY_CATEGORY,
   CORE_VERSION,
-  CoreWidgetName
+  CoreWidgetName,
 } from '@sunmao-ui/shared';
+export { PREVENT_POPOVER_WIDGET_CLOSE_CLASS } from './widget';

--- a/packages/editor-sdk/src/constants/widget.ts
+++ b/packages/editor-sdk/src/constants/widget.ts
@@ -1,0 +1,1 @@
+export const PREVENT_POPOVER_WIDGET_CLOSE_CLASS = 'prevent-popover-widget-close';


### PR DESCRIPTION
when clicking the outside node which would stop propagation, it can't close the popover widget