### PR TITLE
fix: fix the `exampleProperties` type errors

### DIFF
--- a/packages/arco-lib/src/sunmao-helper.ts
+++ b/packages/arco-lib/src/sunmao-helper.ts
@@ -36,10 +36,10 @@ export const getComponentProps = <
   TState,
   TMethods,
   TSlots extends Record<string, SlotSpec>,
-  KStyleSlot extends string,
-  KEvent extends string
+  KStyleSlots extends ReadonlyArray<string>,
+  KEvents extends ReadonlyArray<string>
 >(
-  props: T & ComponentImplProps<T, TState, TMethods, TSlots, KStyleSlot, KEvent>
+  props: T & ComponentImplProps<T, TState, TMethods, TSlots, KStyleSlots, KEvents>
 ) => {
   const {
     /* eslint-disable @typescript-eslint/no-unused-vars */

--- a/packages/chakra-ui-lib/src/components/Table/spec.ts
+++ b/packages/chakra-ui-lib/src/components/Table/spec.ts
@@ -24,7 +24,6 @@ const PropsSpec = Type.Object({
 });
 
 export const implementTable = implementRuntimeComponent({
-  kind: 'Component',
   version: 'chakra_ui/v1',
   metadata: {
     name: 'table',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,6 @@
   "devDependencies": {
     "@swc/core": "^1.2.121",
     "@sinclair/typebox": "^0.21.2",
-    "@sunmao-ui/shared": "^0.2.3",
     "@types/jest": "^26.0.23",
     "@types/json-schema": "^7.0.7",
     "@types/lodash": "^4.14.182",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,8 @@
   },
   "devDependencies": {
     "@swc/core": "^1.2.121",
+    "@sinclair/typebox": "^0.21.2",
+    "@sunmao-ui/shared": "^0.2.3",
     "@types/jest": "^26.0.23",
     "@types/json-schema": "^7.0.7",
     "@types/lodash": "^4.14.182",

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -1,59 +1,78 @@
 import { JSONSchema7 } from 'json-schema';
+import type { Static } from '@sinclair/typebox';
+import type { DeepPartial } from '@sunmao-ui/shared';
 import { parseVersion, Version } from './version';
 import { ComponentMetadata } from './metadata';
 import { MethodSchema } from './method';
 import { SlotSpec } from './slot';
 
 type ComponentSpec<
-  KMethodName extends string,
-  KStyleSlot extends string,
-  KSlot extends string,
-  KEvent extends string
+  KProperties extends JSONSchema7,
+  KState extends JSONSchema7,
+  KMethods extends Record<string, MethodSchema['parameters']>,
+  KStyleSlots extends ReadonlyArray<string>,
+  KSlots extends Record<string, SlotSpec>,
+  KEvents extends ReadonlyArray<string>
 > = {
-  properties: JSONSchema7;
-  state: JSONSchema7;
-  methods: Record<KMethodName, MethodSchema['parameters']>;
-  styleSlots: ReadonlyArray<KStyleSlot>;
-  slots: Record<KSlot, SlotSpec>;
-  events: ReadonlyArray<KEvent>;
+  properties: KProperties;
+  state: KState;
+  methods: KMethods;
+  styleSlots: KStyleSlots;
+  slots: KSlots;
+  events: KEvents;
 };
 
 export type Component<
-  KMethodName extends string,
-  KStyleSlot extends string,
-  KSlot extends string,
-  KEvent extends string
+  KProperties extends JSONSchema7,
+  KState extends JSONSchema7,
+  KMethods extends Record<string, MethodSchema['parameters']>,
+  KStyleSlots extends ReadonlyArray<string>,
+  KSlots extends Record<string, SlotSpec>,
+  KEvents extends ReadonlyArray<string>
 > = {
   version: string;
   kind: 'Component';
-  metadata: ComponentMetadata;
-  spec: ComponentSpec<KMethodName, KStyleSlot, KSlot, KEvent>;
+  metadata: ComponentMetadata<DeepPartial<Static<KProperties>>>;
+  spec: ComponentSpec<KProperties, KState, KMethods, KStyleSlots, KSlots, KEvents>;
 };
 
 export type RuntimeComponent<
-  KMethodName extends string,
-  KStyleSlot extends string,
-  KSlot extends string,
-  KEvent extends string
-> = Component<KMethodName, KStyleSlot, KSlot, KEvent> & {
+  KProperties extends JSONSchema7,
+  KState extends JSONSchema7,
+  KMethods extends Record<string, MethodSchema['parameters']>,
+  KStyleSlots extends ReadonlyArray<string>,
+  KSlots extends Record<string, SlotSpec>,
+  KEvents extends ReadonlyArray<string>
+> = Component<KProperties, KState, KMethods, KStyleSlots, KSlots, KEvents> & {
   parsedVersion: Version;
 };
 
 export type CreateComponentOptions<
-  KMethodName extends string,
-  KStyleSlot extends string,
-  KSlot extends string,
-  KEvent extends string
-> = Omit<Component<KMethodName, KStyleSlot, KSlot, KEvent>, 'kind'>;
+  KProperties extends JSONSchema7,
+  KState extends JSONSchema7,
+  KMethods extends Record<string, MethodSchema['parameters']>,
+  KStyleSlots extends ReadonlyArray<string>,
+  KSlots extends Record<string, SlotSpec>,
+  KEvents extends ReadonlyArray<string>
+> = Omit<Component<KProperties, KState, KMethods, KStyleSlots, KSlots, KEvents>, 'kind'>;
 
 export function createComponent<
-  KMethodName extends string,
-  KStyleSlot extends string,
-  KSlot extends string,
-  KEvent extends string
+  KProperties extends JSONSchema7,
+  KState extends JSONSchema7,
+  KMethods extends Record<string, MethodSchema['parameters']>,
+  KStyleSlots extends ReadonlyArray<string>,
+  KSlots extends Record<string, SlotSpec>,
+  KEvents extends ReadonlyArray<string>
 >(
-  options: CreateComponentOptions<KMethodName, KStyleSlot, KSlot, KEvent>
-): RuntimeComponent<KMethodName, KStyleSlot, KSlot, KEvent> {
+  options: CreateComponentOptions<
+    KProperties,
+    KState,
+    KMethods,
+    KStyleSlots,
+    KSlots,
+    KEvents
+  >
+): RuntimeComponent<KProperties, KState, KMethods, KStyleSlots, KSlots, KEvents> {
   return {
     ...options,
     kind: 'Component',

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -1,10 +1,15 @@
 import { JSONSchema7 } from 'json-schema';
 import type { Static } from '@sinclair/typebox';
-import type { DeepPartial } from '@sunmao-ui/shared';
 import { parseVersion, Version } from './version';
 import { ComponentMetadata } from './metadata';
 import { MethodSchema } from './method';
 import { SlotSpec } from './slot';
+
+type DeepPartial<T> = T extends Record<string, any> | Record<string, any>[]
+  ? Partial<{
+      [K in keyof T]: DeepPartial<T[K]>;
+    }>
+  : T;
 
 type ComponentSpec<
   KProperties extends JSONSchema7,

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -1,10 +1,11 @@
-import { JSONSchema7Object } from 'json-schema';
-
-export type Metadata<TAnnotations = Record<string, unknown>> = {
+export type Metadata<
+  TAnnotations = Record<string, unknown>,
+  TExample = Record<string, any>
+> = {
   name: string;
   description?: string;
   annotations?: Record<string, any> & TAnnotations;
-  exampleProperties?: JSONSchema7Object;
+  exampleProperties?: TExample;
 };
 
 type ComponentCategory =
@@ -15,7 +16,10 @@ type ComponentCategory =
   | 'Advance'
   | undefined;
 
-export type ComponentMetadata = Metadata<{ category?: ComponentCategory }> & {
+export type ComponentMetadata<TExample = Record<string, any>> = Metadata<
+  { category?: ComponentCategory },
+  TExample
+> & {
   // TODO:(yanzhen): move to annotations
   displayName: string;
   icon?: string;

--- a/packages/editor/src/AppModel/ComponentModel.ts
+++ b/packages/editor/src/AppModel/ComponentModel.ts
@@ -6,7 +6,12 @@ import {
   CoreTraitName,
   AnyTypePlaceholder,
 } from '@sunmao-ui/shared';
-import { ComponentSchema, MethodSchema, RuntimeComponent } from '@sunmao-ui/core';
+import {
+  ComponentSchema,
+  MethodSchema,
+  RuntimeComponent,
+  SlotSpec,
+} from '@sunmao-ui/core';
 import { genComponent, genTrait } from './utils';
 import {
   ComponentId,
@@ -32,10 +37,12 @@ const DynamicStateTrait = [
 ];
 
 type ComponentSpecModel = RuntimeComponent<
-  MethodName,
-  StyleSlotName,
-  SlotName,
-  EventName
+  any,
+  any,
+  Record<MethodName, MethodSchema['parameters']>,
+  ReadonlyArray<StyleSlotName>,
+  Record<SlotName, SlotSpec>,
+  ReadonlyArray<EventName>
 >;
 export class ComponentModel implements IComponentModel {
   spec: ComponentSpecModel;

--- a/packages/editor/src/components/ComponentsList/ComponentList.tsx
+++ b/packages/editor/src/components/ComponentsList/ComponentList.tsx
@@ -16,9 +16,10 @@ import { CoreComponentName, CORE_VERSION } from '@sunmao-ui/shared';
 import { groupBy, sortBy } from 'lodash';
 import { EditorServices } from '../../types';
 import { ExplorerMenuTabs } from '../../constants/enum';
-import { RuntimeComponent } from '@sunmao-ui/core';
+import { RuntimeComponent, SlotSpec } from '@sunmao-ui/core';
 import { css } from '@emotion/css';
 import { ComponentFilter } from './ComponentFilter';
+import { JSONSchema7 } from 'json-schema';
 
 type Props = {
   services: EditorServices;
@@ -26,7 +27,14 @@ type Props = {
 
 type Category = {
   name: string;
-  components: RuntimeComponent<string, string, string, string>[];
+  components: RuntimeComponent<
+    any,
+    any,
+    Record<string, JSONSchema7 | undefined>,
+    ReadonlyArray<string>,
+    Record<string, SlotSpec>,
+    ReadonlyArray<string>
+  >[];
 };
 
 const PRESET_CATEGORY_ORDER = {

--- a/packages/editor/src/validator/SchemaValidator.ts
+++ b/packages/editor/src/validator/SchemaValidator.ts
@@ -1,4 +1,4 @@
-import { RuntimeComponent } from '@sunmao-ui/core';
+import { RuntimeComponent, SlotSpec } from '@sunmao-ui/core';
 import { RegistryInterface } from '@sunmao-ui/runtime';
 import Ajv from 'ajv';
 import { PropertiesValidatorRule } from '.';
@@ -13,6 +13,7 @@ import {
   ValidatorMap,
 } from './interfaces';
 import { rules } from './rules';
+import { JSONSchema7 } from 'json-schema';
 
 export class SchemaValidator implements ISchemaValidator {
   private result: ValidateErrorResult[] = [];
@@ -22,7 +23,14 @@ export class SchemaValidator implements ISchemaValidator {
   private propertiesRules: PropertiesValidatorRule[] = [];
   private componentIdSpecMap: Record<
     string,
-    RuntimeComponent<string, string, string, string>
+    RuntimeComponent<
+      any,
+      any,
+      Record<string, JSONSchema7 | undefined>,
+      ReadonlyArray<string>,
+      Record<string, SlotSpec>,
+      ReadonlyArray<string>
+    >
   > = {};
 
   private ajv!: Ajv;

--- a/packages/editor/src/validator/interfaces.ts
+++ b/packages/editor/src/validator/interfaces.ts
@@ -1,4 +1,4 @@
-import { ComponentSchema, RuntimeComponent } from '@sunmao-ui/core';
+import { ComponentSchema, RuntimeComponent, SlotSpec } from '@sunmao-ui/core';
 import { RegistryInterface } from '@sunmao-ui/runtime';
 import Ajv, { ValidateFunction } from 'ajv';
 import { AppModel } from '../AppModel/AppModel';
@@ -8,6 +8,7 @@ import {
   IFieldModel,
   ITraitModel,
 } from '../AppModel/IAppModel';
+import { JSONSchema7 } from 'json-schema';
 
 export interface ValidatorMap {
   components: Record<string, ValidateFunction>;
@@ -22,7 +23,17 @@ interface BaseValidateContext {
   appModel: IAppModel;
   ajv: Ajv;
   dependencyNames: string[];
-  componentIdSpecMap: Record<string, RuntimeComponent<string, string, string, string>>;
+  componentIdSpecMap: Record<
+    string,
+    RuntimeComponent<
+      any,
+      any,
+      Record<string, JSONSchema7 | undefined>,
+      ReadonlyArray<string>,
+      Record<string, SlotSpec>,
+      ReadonlyArray<string>
+    >
+  >;
 }
 
 export interface ComponentValidateContext extends BaseValidateContext {

--- a/packages/runtime/src/components/_internal/ImplWrapper/ImplWrapperMain.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper/ImplWrapperMain.tsx
@@ -28,20 +28,20 @@ export const ImplWrapperMain = React.forwardRef<HTMLDivElement, ImplWrapperProps
 
     const { mergeState, subscribeMethods, executeTrait } = useRuntimeFunctions(props);
 
-    const [traitResults, setTraitResults] = useState<TraitResult<string, string>[]>(
-      () => {
-        return c.traits.map(t =>
-          executeTrait(
-            t,
-            stateManager.deepEval(t.properties, {
-              evalListItem,
-              scopeObject: { $slot: slotProps },
-              fallbackWhenError: () => undefined,
-            })
-          )
-        );
-      }
-    );
+    const [traitResults, setTraitResults] = useState<
+      TraitResult<ReadonlyArray<string>, ReadonlyArray<string>>[]
+    >(() => {
+      return c.traits.map(t =>
+        executeTrait(
+          t,
+          stateManager.deepEval(t.properties, {
+            evalListItem,
+            scopeObject: { $slot: slotProps },
+            fallbackWhenError: () => undefined,
+          })
+        )
+      );
+    });
 
     useEffect(() => {
       return () => {
@@ -81,9 +81,15 @@ export const ImplWrapperMain = React.forwardRef<HTMLDivElement, ImplWrapperProps
     }, [c.id, c.traits, executeTrait, stateManager, slotProps, evalListItem]);
 
     // reduce traitResults
-    const propsFromTraits: TraitResult<string, string>['props'] = useMemo(() => {
+    const propsFromTraits: TraitResult<
+      ReadonlyArray<string>,
+      ReadonlyArray<string>
+    >['props'] = useMemo(() => {
       return Array.from(traitResults.values()).reduce(
-        (prevProps, result: TraitResult<string, string>) => {
+        (
+          prevProps,
+          result: TraitResult<ReadonlyArray<string>, ReadonlyArray<string>>
+        ) => {
           if (!result.props) {
             return prevProps;
           }
@@ -96,7 +102,7 @@ export const ImplWrapperMain = React.forwardRef<HTMLDivElement, ImplWrapperProps
             }
           });
         },
-        {} as TraitResult<string, string>['props']
+        {} as TraitResult<ReadonlyArray<string>, ReadonlyArray<string>>['props']
       );
     }, [traitResults]);
 

--- a/packages/runtime/src/components/_internal/ImplWrapper/UnmountImplWrapper.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper/UnmountImplWrapper.tsx
@@ -23,12 +23,13 @@ export const UnmountImplWrapper = React.forwardRef<HTMLDivElement, ImplWrapperPr
     );
 
     const [isHidden, setIsHidden] = useState(() => {
-      const results: TraitResult<string, string>[] = unmountTraits.map(t => {
-        const properties = stateManager.deepEval(t.properties, {
-          scopeObject: { $slot: props.slotProps },
+      const results: TraitResult<ReadonlyArray<string>, ReadonlyArray<string>>[] =
+        unmountTraits.map(t => {
+          const properties = stateManager.deepEval(t.properties, {
+            scopeObject: { $slot: props.slotProps },
+          });
+          return executeTrait(t, properties);
         });
-        return executeTrait(t, properties);
-      });
       return results.some(result => result.unmount);
     });
 

--- a/packages/runtime/src/services/Registry.tsx
+++ b/packages/runtime/src/services/Registry.tsx
@@ -1,4 +1,5 @@
-import { parseType } from '@sunmao-ui/core';
+import { JSONSchema7 } from 'json-schema';
+import { parseType, SlotSpec } from '@sunmao-ui/core';
 // components
 /* --- core --- */
 import CoreText from '../components/core/Text';
@@ -36,17 +37,26 @@ import { ImplementedUtilMethod } from '../types/utilMethod';
 import { UtilMethodManager } from './UtilMethodManager';
 
 export type SunmaoLib = {
-  components?: ImplementedRuntimeComponent<string, string, string, string>[];
+  components?: ImplementedRuntimeComponent<
+    any,
+    any,
+    Record<string, JSONSchema7 | undefined>,
+    ReadonlyArray<string>,
+    Record<string, SlotSpec>,
+    ReadonlyArray<string>
+  >[];
   traits?: ImplementedRuntimeTraitFactory[];
   modules?: ImplementedRuntimeModule[];
   utilMethods?: UtilMethodFactory[];
 };
 
 type AnyImplementedRuntimeComponent = ImplementedRuntimeComponent<
-  string,
-  string,
-  string,
-  string
+  any,
+  any,
+  Record<string, JSONSchema7 | undefined>,
+  ReadonlyArray<string>,
+  Record<string, SlotSpec>,
+  ReadonlyArray<string>
 >;
 
 export type RegistryInterface = InstanceType<typeof Registry>;

--- a/packages/runtime/src/types/component.ts
+++ b/packages/runtime/src/types/component.ts
@@ -1,9 +1,11 @@
+import { JSONSchema7 } from 'json-schema';
 import { Static } from '@sinclair/typebox';
 import {
   RuntimeApplication,
   RuntimeComponentSchema,
   RuntimeComponent,
   SlotSpec,
+  MethodSchema,
 } from '@sunmao-ui/core';
 import React from 'react';
 import { UIServices, ComponentParamsFromApp } from './application';
@@ -29,10 +31,10 @@ export type ComponentImplProps<
   TState,
   TMethods,
   TSlots extends Record<string, SlotSpec>,
-  KStyleSlot extends string,
-  KEvent extends string
+  KStyleSlots extends ReadonlyArray<string>,
+  KEvents extends ReadonlyArray<string>
 > = ImplWrapperProps<TProps, string> &
-  TraitResult<KStyleSlot, KEvent>['props'] &
+  TraitResult<KStyleSlots, KEvents>['props'] &
   RuntimeFunctions<TState, TMethods, TSlots> & {
     elementRef?: React.MutableRefObject<any>;
     getElement?: (ele: HTMLElement) => void;
@@ -40,21 +42,23 @@ export type ComponentImplProps<
 
 export type ComponentImpl<
   TProps extends Record<string, unknown> = Record<string, unknown>,
-  TState = any,
+  TState = Record<string, any>,
   TMethods = Record<string, any>,
   TSlots extends Record<string, SlotSpec> = Record<string, any>,
-  KStyleSlot extends string = string,
-  KEvent extends string = string
+  KStyleSlots extends ReadonlyArray<string> = ReadonlyArray<string>,
+  KEvents extends ReadonlyArray<string> = ReadonlyArray<string>
 > = React.FC<
-  TProps & ComponentImplProps<TProps, TState, TMethods, TSlots, KStyleSlot, KEvent>
+  TProps & ComponentImplProps<TProps, TState, TMethods, TSlots, KStyleSlots, KEvents>
 >;
 
 export type ImplementedRuntimeComponent<
-  KMethodName extends string,
-  KStyleSlot extends string,
-  KSlot extends string,
-  KEvent extends string
-> = RuntimeComponent<KMethodName, KStyleSlot, KSlot, KEvent> & {
+  KProperties extends JSONSchema7,
+  KState extends JSONSchema7,
+  KMethods extends Record<string, MethodSchema['parameters']>,
+  KStyleSlots extends ReadonlyArray<string>,
+  KSlots extends Record<string, SlotSpec>,
+  KEvents extends ReadonlyArray<string>
+> = RuntimeComponent<KProperties, KState, KMethods, KStyleSlots, KSlots, KEvents> & {
   impl: ComponentImpl<any>;
 };
 

--- a/packages/runtime/src/types/trait.ts
+++ b/packages/runtime/src/types/trait.ts
@@ -2,11 +2,16 @@ import { RuntimeTrait, RuntimeTraitSchema } from '@sunmao-ui/core';
 import { UIServices } from './application';
 import { RuntimeFunctions } from './component';
 
-export type TraitResult<KStyleSlot extends string, KEvent extends string> = {
+type ToStringUnion<T extends ReadonlyArray<string>> = T[number];
+
+export type TraitResult<
+  KStyleSlots extends ReadonlyArray<string>,
+  KEvents extends ReadonlyArray<string>
+> = {
   props: {
     data?: unknown;
-    customStyle?: Record<KStyleSlot, string>;
-    callbackMap?: CallbackMap<KEvent>;
+    customStyle?: Record<ToStringUnion<KStyleSlots>, string>;
+    callbackMap?: CallbackMap<ToStringUnion<KEvents>>;
     componentDidUnmount?: Array<() => void>;
     componentDidMount?: Array<() => Function | void>;
     componentDidUpdate?: Array<() => Function | void>;
@@ -23,7 +28,7 @@ export type TraitImpl<TProperties = any> = (
       evalListItem?: boolean;
       slotProps?: unknown;
     }
-) => TraitResult<string, string>;
+) => TraitResult<ReadonlyArray<string>, ReadonlyArray<string>>;
 
 export type TraitImplFactory<T = any> = () => TraitImpl<T>;
 

--- a/packages/runtime/src/utils/buildKit.ts
+++ b/packages/runtime/src/utils/buildKit.ts
@@ -1,4 +1,5 @@
 import { Static } from '@sinclair/typebox';
+import { JSONSchema7 } from 'json-schema';
 import {
   createComponent,
   CreateComponentOptions,
@@ -7,8 +8,9 @@ import {
   TraitSpec,
   createUtilMethod,
   CreateUtilMethodOptions,
+  SlotSpec,
+  MethodSchema,
 } from '@sunmao-ui/core';
-import { type DeepPartial } from '@sunmao-ui/shared';
 import {
   ComponentImpl,
   ImplementedRuntimeComponent,
@@ -25,27 +27,61 @@ type ToMap<U> = {
 type ToStringUnion<T extends ReadonlyArray<string>> = T[number];
 
 export function implementRuntimeComponent<
-  KMethodName extends string,
-  KStyleSlot extends string,
-  KSlot extends string,
+  KStyle extends string,
   KEvent extends string,
-  T extends CreateComponentOptions<KMethodName, KStyleSlot, KSlot, KEvent>
+  T extends CreateComponentOptions<
+    T['spec']['properties'] extends JSONSchema7 ? T['spec']['properties'] : JSONSchema7,
+    T['spec']['state'] extends JSONSchema7 ? T['spec']['state'] : JSONSchema7,
+    T['spec']['methods'] extends Record<string, MethodSchema['parameters']>
+      ? T['spec']['methods']
+      : Record<string, MethodSchema['parameters']>,
+    ToStringUnion<T['spec']['styleSlots']> extends KStyle
+      ? ReadonlyArray<ToStringUnion<T['spec']['styleSlots']>>
+      : ReadonlyArray<KStyle>,
+    T['spec']['slots'] extends Record<string, SlotSpec>
+      ? T['spec']['slots']
+      : Record<string, SlotSpec>,
+    ToStringUnion<T['spec']['events']> extends KEvent
+      ? ReadonlyArray<ToStringUnion<T['spec']['events']>>
+      : ReadonlyArray<KEvent>
+  >
 >(
-  options: T & {
-    metadata: { exampleProperties: DeepPartial<Static<T['spec']['properties']>> };
-  }
+  options: T
 ): (
   impl: ComponentImpl<
     Static<T['spec']['properties']> extends Record<string, unknown>
       ? Static<T['spec']['properties']>
       : Record<string, unknown>,
-    Static<T['spec']['state']>,
+    Static<T['spec']['state']> extends Record<string, any>
+      ? Static<T['spec']['state']>
+      : Record<string, any>,
     ToMap<T['spec']['methods']>,
-    T['spec']['slots'],
-    ToStringUnion<T['spec']['styleSlots']>,
-    ToStringUnion<T['spec']['events']>
+    T['spec']['slots'] extends Record<string, SlotSpec>
+      ? T['spec']['slots']
+      : Record<string, SlotSpec>,
+    ToStringUnion<T['spec']['styleSlots']> extends KStyle
+      ? ReadonlyArray<ToStringUnion<T['spec']['styleSlots']>>
+      : ReadonlyArray<KStyle>,
+    ToStringUnion<T['spec']['events']> extends KEvent
+      ? ReadonlyArray<ToStringUnion<T['spec']['events']>>
+      : ReadonlyArray<KEvent>
   >
-) => ImplementedRuntimeComponent<KMethodName, KStyleSlot, KSlot, KEvent> {
+) => ImplementedRuntimeComponent<
+  T['spec']['properties'] extends JSONSchema7 ? T['spec']['properties'] : JSONSchema7,
+  T['spec']['state'] extends JSONSchema7 ? T['spec']['state'] : JSONSchema7,
+  T['spec']['methods'] extends Record<string, MethodSchema['parameters']>
+    ? T['spec']['methods']
+    : Record<string, MethodSchema['parameters']>,
+  ToStringUnion<T['spec']['styleSlots']> extends KStyle
+    ? ReadonlyArray<ToStringUnion<T['spec']['styleSlots']>>
+    : ReadonlyArray<KStyle>,
+  T['spec']['slots'] extends Record<string, SlotSpec>
+    ? T['spec']['slots']
+    : Record<string, SlotSpec>,
+  ToStringUnion<T['spec']['events']> extends KEvent
+    ? ReadonlyArray<ToStringUnion<T['spec']['events']>>
+    : ReadonlyArray<KEvent>
+> {
   return impl => ({
     ...createComponent(options),
     impl,

--- a/packages/shared/src/types/utils.ts
+++ b/packages/shared/src/types/utils.ts
@@ -1,4 +1,4 @@
-export type DeepPartial<T> = T extends Record<string, any>
+export type DeepPartial<T> = T extends Record<string, any> | Record<string, any>[]
   ? Partial<{
       [K in keyof T]: DeepPartial<T[K]>;
     }>


### PR DESCRIPTION
The previous approach causes the 'exampleProperties' error when the component property is Record type.

Because the type of `T & {
    metadata: { exampleProperties: DeepPartial<Static<T['spec']['properties']>> };
  }` is a hack way to validate the `exampleProperties`, it would cause errors in some situations. 

<img width="846" alt="image" src="https://user-images.githubusercontent.com/25414733/184565197-164077ea-b4c5-426a-98f9-a6795e43cb33.png">

<img width="625" alt="image" src="https://user-images.githubusercontent.com/25414733/184565230-efc5b93c-c7a8-4793-8e47-4ad27c128908.png">

This PR uses the generics type as the `exampleProperties` type, then fixes the errors.

