### PR TITLE
fix: fix selecting component would change the properties' values issue

### DIFF
--- a/packages/editor/src/components/ComponentForm/ComponentForm.tsx
+++ b/packages/editor/src/components/ComponentForm/ComponentForm.tsx
@@ -144,7 +144,7 @@ export const ComponentForm: React.FC<Props> = observer(props => {
           <FormSection
             style={{ position: 'relative', zIndex: sections.length - i }}
             title={section.title}
-            key={section.title}
+            key={`${section.title}-${selectedComponentId}`}
           >
             {section.node}
           </FormSection>


### PR DESCRIPTION
## Issue
When selecting a component, it would change the properties' values.

### Repetition steps
1. Refresh
2. Select the component whose `ifCondition` doesn't use the expression
3. Select another component whose `ifCondition` uses the expression
4. You can see the expression would be a switch component, and the `ifCondition` value is `true`

https://user-images.githubusercontent.com/25414733/185020448-99f30db1-3e56-47b9-8739-283a5af2f5a5.mov

## Reason
The different components would reuse the form, when selecting another component it would trigger the widget's `useEffect` and then would change the value.

![image](https://user-images.githubusercontent.com/25414733/185020555-6ff370e0-364c-41f7-aa76-9a1322fbf772.png)

## Fix
Add the different keys for the different component forms.

