### PR TITLE
refactor(runtime): refactor utilMethodFactory type

### DIFF
--- a/packages/arco-lib/src/methods/Message.ts
+++ b/packages/arco-lib/src/methods/Message.ts
@@ -20,7 +20,7 @@ const ParameterSpec = Type.Object({
 });
 
 export const MessageUtilMethodFactory = () => {
-  const Message = implementUtilMethod({
+  return implementUtilMethod({
     version: 'arco/v1',
     metadata: {
       name: 'message',
@@ -39,6 +39,4 @@ export const MessageUtilMethodFactory = () => {
       ...rest,
     });
   });
-
-  return [Message];
 };

--- a/packages/chakra-ui-lib/src/components/Types/Toast.ts
+++ b/packages/chakra-ui-lib/src/components/Types/Toast.ts
@@ -67,9 +67,9 @@ const pickProperty = <T, U extends Record<string, any>>(
   return result as Partial<Static<TObject<T>>>;
 };
 
-export default function ToastUtilMethodFactory() {
-  let toast: ReturnType<typeof createStandaloneToast> | undefined;
+const toastInstances: Record<string, ReturnType<typeof createStandaloneToast>> = {};
 
+export function ToastOpenUtilMethodFactory(sunmaoInstanceKey: string) {
   const toastOpen = implementUtilMethod({
     version: 'chakra_ui/v1',
     metadata: {
@@ -79,14 +79,18 @@ export default function ToastUtilMethodFactory() {
       parameters: ToastOpenParameterSpec,
     },
   })(parameters => {
-    if (!toast) {
-      toast = createStandaloneToast();
+    if (!toastInstances[sunmaoInstanceKey]) {
+      toastInstances[sunmaoInstanceKey] = createStandaloneToast();
     }
     if (parameters) {
-      toast(pickProperty(ToastOpenParameterSpec, parameters));
+      toastInstances[sunmaoInstanceKey](pickProperty(ToastOpenParameterSpec, parameters));
     }
   });
 
+  return toastOpen;
+}
+
+export function ToastCloseUtilMethodFactory(sunmaoInstanceKey: string) {
   const toastClose = implementUtilMethod({
     version: 'chakra_ui/v1',
     metadata: {
@@ -96,6 +100,7 @@ export default function ToastUtilMethodFactory() {
       parameters: ToastCloseParameterSpec,
     },
   })(parameters => {
+    const toast = toastInstances[sunmaoInstanceKey];
     if (!toast) {
       return;
     }
@@ -111,5 +116,5 @@ export default function ToastUtilMethodFactory() {
     }
   });
 
-  return [toastOpen, toastClose];
+  return toastClose;
 }

--- a/packages/chakra-ui-lib/src/index.ts
+++ b/packages/chakra-ui-lib/src/index.ts
@@ -25,7 +25,10 @@ import ChakraUIDialog from './components/Dialog';
 import ChakraUISelect from './components/Select';
 import ChakraUIRadioGroup from './components/RadioGroup';
 import ChakraUIRadio from './components/Radio';
-import ChakraUIToastUtilMethodFactory from './components/Types/Toast';
+import {
+  ToastOpenUtilMethodFactory,
+  ToastCloseUtilMethodFactory,
+} from './components/Types/Toast';
 
 export const sunmaoChakraUILib: SunmaoLib = {
   components: [
@@ -58,7 +61,7 @@ export const sunmaoChakraUILib: SunmaoLib = {
   ],
   traits: [],
   modules: [],
-  utilMethods: [ChakraUIToastUtilMethodFactory],
+  utilMethods: [ToastOpenUtilMethodFactory, ToastCloseUtilMethodFactory],
 };
 
 export { widgets } from './widgets';

--- a/packages/runtime/src/services/Registry.tsx
+++ b/packages/runtime/src/services/Registry.tsx
@@ -66,6 +66,7 @@ export class Registry {
   traits = new Map<string, Map<string, ImplementedRuntimeTrait>>();
   modules = new Map<string, Map<string, ImplementedRuntimeModule>>();
   utilMethods = new Map<string, Map<string, ImplementedUtilMethod>>();
+  private sunmaoInstanceKey = String(Math.floor(Date.now() / 1000));
   private services: UIServices;
 
   constructor(
@@ -234,8 +235,7 @@ export class Registry {
     lib.modules?.forEach(m => this.registerModule(m));
     if (lib.utilMethods) {
       lib.utilMethods.forEach(factory => {
-        const methods = factory();
-        methods.forEach(m => this.registerUtilMethod(m));
+        this.registerUtilMethod(factory(this.sunmaoInstanceKey));
       });
     }
   }

--- a/packages/runtime/src/types/utilMethod.ts
+++ b/packages/runtime/src/types/utilMethod.ts
@@ -7,4 +7,4 @@ export type ImplementedUtilMethod<T = any> = RuntimeUtilMethod & {
   impl: UtilMethodImpl<T>;
 };
 
-export type UtilMethodFactory = () => ImplementedUtilMethod<any>[];
+export type UtilMethodFactory = (sunmaoInstanceKey: string) => ImplementedUtilMethod<any>;


### PR DESCRIPTION
Refactor `UtilMethodFactory` type to keep the same style with `TraitFactory`.
before:
`export type UtilMethodFactory = () => ImplementedUtilMethod<any>[]`
after:
`export type UtilMethodFactory = (sunmaoInstanceKey: string) => ImplementedUtilMethod<any>`

`sunmaoInstanceKey` is a new parameter. It is optional. Its purpose is to let the utilMethod know which Sunmao Instance is calling it.