### PR TITLE
fix(BooleanField): convert only the values that exist

### DIFF
--- a/packages/editor-sdk/src/components/Widgets/BooleanField.tsx
+++ b/packages/editor-sdk/src/components/Widgets/BooleanField.tsx
@@ -16,7 +16,7 @@ export const BooleanField: React.FC<WidgetProps<BooleanFieldType>> = props => {
 
   useEffect(() => {
     // Convert value to boolean after switch from expression widget mode.
-    if (typeof value !== 'boolean') {
+    if (value && typeof value !== 'boolean') {
       onChange(true);
     }
   }, [onChange, value]);


### PR DESCRIPTION
Previously, booleanfield would accidentally convert undefined to true, now it only converts non-empty values