### PR TITLE
refactor(runtime): export generateCallback and rename to runEventHandler

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -65,6 +65,7 @@ export function initSunmaoUI(props: SunmaoUIRuntimeProps = {}) {
 }
 
 export * from './utils/buildKit';
+export * from './utils/runEventHandler';
 export * from './types';
 export * from './constants';
 export * from './traits/core';

--- a/packages/runtime/src/traits/core/Event.tsx
+++ b/packages/runtime/src/traits/core/Event.tsx
@@ -1,65 +1,13 @@
-import { Static, Type } from '@sinclair/typebox';
-import { debounce, throttle, delay } from 'lodash';
-import { CallbackMap, UIServices } from '../../types';
+import { Type } from '@sinclair/typebox';
+import { CallbackMap } from '../../types';
 import { implementRuntimeTrait } from '../../utils/buildKit';
-import {
-  EventHandlerSpec,
-  EventCallBackHandlerSpec,
-  CORE_VERSION,
-  CoreTraitName,
-} from '@sunmao-ui/shared';
-import { type PropsBeforeEvaled } from '@sunmao-ui/core';
+import { EventHandlerSpec, CORE_VERSION, CoreTraitName } from '@sunmao-ui/shared';
+import { runEventHandler } from '../../utils/runEventHandler';
 
 const HandlersSpec = Type.Array(EventHandlerSpec);
-const CallbackSpec = Type.Array(EventCallBackHandlerSpec);
 export const EventTraitPropertiesSpec = Type.Object({
   handlers: HandlersSpec,
 });
-
-export const generateCallback = (
-  handler: Omit<Static<typeof EventCallBackHandlerSpec>, 'type'>,
-  rawHandlers: string | PropsBeforeEvaled<Static<typeof CallbackSpec>>,
-  index: number,
-  services: UIServices,
-  slotKey: string,
-  evalListItem?: boolean
-) => {
-  const { stateManager } = services;
-  const send = () => {
-    // Eval before sending event to assure the handler object is evaled from the latest state.
-    const evalOptions = {
-      slotKey,
-      evalListItem,
-    };
-    const evaledHandlers = stateManager.deepEval(rawHandlers, evalOptions) as Static<
-      typeof EventCallBackHandlerSpec
-    >[];
-    const evaledHandler = evaledHandlers[index];
-
-    if (evaledHandler.disabled && typeof evaledHandler.disabled === 'boolean') {
-      return;
-    }
-
-    services.apiService.send('uiMethod', {
-      componentId: evaledHandler.componentId,
-      name: evaledHandler.method.name,
-      parameters: evaledHandler.method.parameters,
-    });
-  };
-  const { wait } = handler;
-
-  if (!wait || !wait.time) {
-    return send;
-  }
-
-  return wait.type === 'debounce'
-    ? debounce(send, wait.time)
-    : wait.type === 'throttle'
-    ? throttle(send, wait.time)
-    : wait.type === 'delay'
-    ? () => delay(send, wait!.time)
-    : send;
-};
 
 export default implementRuntimeTrait({
   version: CORE_VERSION,
@@ -84,7 +32,7 @@ export default implementRuntimeTrait({
         callbackQueueMap[handler.type] = [];
       }
       callbackQueueMap[handler.type].push(
-        generateCallback(handler, rawHandlers, Number(i), services, slotKey, evalListItem)
+        runEventHandler(handler, rawHandlers, Number(i), services, slotKey, evalListItem)
       );
     }
 

--- a/packages/runtime/src/traits/core/Fetch.tsx
+++ b/packages/runtime/src/traits/core/Fetch.tsx
@@ -7,7 +7,7 @@ import {
   CORE_VERSION,
   CoreWidgetName,
 } from '@sunmao-ui/shared';
-import { generateCallback } from './Event';
+import { runEventHandler } from '../../utils/runEventHandler';
 import { implementRuntimeTrait } from '../../utils/buildKit';
 
 export const FetchTraitPropertiesSpec = Type.Object({
@@ -158,7 +158,7 @@ export default implementRuntimeTrait({
             const rawOnComplete = trait.properties.onComplete;
 
             onComplete?.forEach((_, index) => {
-              generateCallback(
+              runEventHandler(
                 onComplete[index],
                 rawOnComplete,
                 index,
@@ -181,7 +181,7 @@ export default implementRuntimeTrait({
             const rawOnError = trait.properties.onError;
 
             onError?.forEach((_, index) => {
-              generateCallback(onError[index], rawOnError, index, services, slotKey)();
+              runEventHandler(onError[index], rawOnError, index, services, slotKey)();
             });
           }
         },
@@ -200,7 +200,7 @@ export default implementRuntimeTrait({
           const rawOnError = trait.properties.onError;
 
           onError?.forEach((_, index) => {
-            generateCallback(onError[index], rawOnError, index, services, slotKey)();
+            runEventHandler(onError[index], rawOnError, index, services, slotKey)();
           });
         }
       );

--- a/packages/runtime/src/utils/runEventHandler.ts
+++ b/packages/runtime/src/utils/runEventHandler.ts
@@ -1,0 +1,52 @@
+import { Static, Type } from '@sinclair/typebox';
+import { debounce, throttle, delay } from 'lodash';
+import { EventCallBackHandlerSpec } from '@sunmao-ui/shared';
+import { type PropsBeforeEvaled } from '@sunmao-ui/core';
+import { UIServices } from '../types';
+
+const CallbackSpec = Type.Array(EventCallBackHandlerSpec);
+
+export const runEventHandler = (
+  handler: Omit<Static<typeof EventCallBackHandlerSpec>, 'type'>,
+  rawHandlers: string | PropsBeforeEvaled<Static<typeof CallbackSpec>>,
+  index: number,
+  services: UIServices,
+  slotKey: string,
+  evalListItem?: boolean
+) => {
+  const { stateManager } = services;
+  const send = () => {
+    // Eval before sending event to assure the handler object is evaled from the latest state.
+    const evalOptions = {
+      slotKey,
+      evalListItem,
+    };
+    const evaledHandlers = stateManager.deepEval(rawHandlers, evalOptions) as Static<
+      typeof EventCallBackHandlerSpec
+    >[];
+    const evaledHandler = evaledHandlers[index];
+
+    if (evaledHandler.disabled && typeof evaledHandler.disabled === 'boolean') {
+      return;
+    }
+
+    services.apiService.send('uiMethod', {
+      componentId: evaledHandler.componentId,
+      name: evaledHandler.method.name,
+      parameters: evaledHandler.method.parameters,
+    });
+  };
+  const { wait } = handler;
+
+  if (!wait || !wait.time) {
+    return send;
+  }
+
+  return wait.type === 'debounce'
+    ? debounce(send, wait.time)
+    : wait.type === 'throttle'
+    ? throttle(send, wait.time)
+    : wait.type === 'delay'
+    ? () => delay(send, wait!.time)
+    : send;
+};


### PR DESCRIPTION
Some 3rd-party custom trait will need to call `generateCallback`, so I export it and rename it to a more proper name.