### PR TITLE
fix(editor): loss of state in ComponentList caused by tab switching

### DIFF
--- a/packages/editor/src/components/ComponentsList/ComponentFilter.tsx
+++ b/packages/editor/src/components/ComponentsList/ComponentFilter.tsx
@@ -80,6 +80,10 @@ export const ComponentFilter: React.FC<FilterProps> = ({
     setCheckedVersions(newCheckedVersions);
   };
 
+  const checkVersion = (version: string) => {
+    return checkedVersions.includes(version);
+  };
+
   return (
     <Popover isLazy closeOnBlur placement="bottom">
       <PopoverTrigger>
@@ -108,7 +112,12 @@ export const ComponentFilter: React.FC<FilterProps> = ({
         >
           {versions.map(version => {
             return (
-              <Checkbox key={version} value={version} onChange={handleChange}>
+              <Checkbox
+                key={version}
+                value={version}
+                isChecked={checkVersion(version)}
+                onChange={handleChange}
+              >
                 {version}
               </Checkbox>
             );

--- a/packages/editor/src/components/Editor.tsx
+++ b/packages/editor/src/components/Editor.tsx
@@ -228,9 +228,10 @@ export const Editor: React.FC<Props> = observer(
                   height="100%"
                   display="flex"
                   flexDirection="column"
+                  lazyBehavior="keepMounted"
+                  isLazy
                   index={toolMenuTab}
                   onChange={onRightTabChange}
-                  isLazy
                 >
                   <TabList background="gray.50">
                     <Tab>Inspect</Tab>


### PR DESCRIPTION
Before fix:
* The filter component information entered by the user is reset after leaving the tab, and the  experience is poor