### PR TITLE
remove evalListItem of parseExpression

### DIFF
--- a/packages/arco-lib/src/components/Table/Table.tsx
+++ b/packages/arco-lib/src/components/Table/Table.tsx
@@ -342,10 +342,13 @@ export const Table = implementRuntimeComponent({
               [LIST_ITEM_EXP]: record,
             },
           };
-          const evaledColumn: ColumnProperty = services.stateManager.deepEval(
-            column,
+
+          const rawColumn = component.properties.columns[i];
+          const evaledColumn = services.stateManager.deepEval(
+            rawColumn,
             evalOptions
-          );
+          ) as ColumnProperty;
+
           const value = record[evaledColumn.dataIndex];
 
           let colItem;
@@ -353,12 +356,7 @@ export const Table = implementRuntimeComponent({
           switch (evaledColumn.type) {
             case 'button':
               const handleClick = () => {
-                const rawColumns = component.properties.columns;
-                const evaledColumns = services.stateManager.deepEval(
-                  rawColumns,
-                  evalOptions
-                ) as ColumnProperty[];
-                const evaledButtonConfig = evaledColumns[i].btnCfg;
+                const evaledButtonConfig = evaledColumn.btnCfg;
 
                 if (!evaledButtonConfig) return;
 

--- a/packages/arco-lib/src/components/Table/Table.tsx
+++ b/packages/arco-lib/src/components/Table/Table.tsx
@@ -338,7 +338,6 @@ export const Table = implementRuntimeComponent({
 
         newColumn.render = (ceilValue: any, record: any, index: number) => {
           const evalOptions = {
-            evalListItem: true,
             scopeObject: {
               [LIST_ITEM_EXP]: record,
             },
@@ -445,7 +444,6 @@ export const Table = implementRuntimeComponent({
                   services={services}
                   childrenMap={{}}
                   isInModule
-                  evalListItem
                   slotContext={{
                     renderSet: new Set(),
                     slotKey: formatSlotKey(

--- a/packages/chakra-ui-lib/src/components/Table/TableTd.tsx
+++ b/packages/chakra-ui-lib/src/components/Table/TableTd.tsx
@@ -45,7 +45,6 @@ export const TableTd: React.FC<{
     slotsElements,
   } = props;
   const evalOptions = {
-    evalListItem: true,
     scopeObject: {
       [LIST_ITEM_EXP]: item,
     },
@@ -150,7 +149,6 @@ export const TableTd: React.FC<{
           services={services}
           childrenMap={{}}
           isInModule
-          evalListItem
           slotContext={{
             renderSet: new Set(),
             slotKey: formatSlotKey(_childrenSchema.id, 'td', `td_${index}`),

--- a/packages/editor-sdk/src/types/editor.ts
+++ b/packages/editor-sdk/src/types/editor.ts
@@ -4,7 +4,6 @@ import WidgetManager from '../models/WidgetManager';
 import type { Operations } from '../types/operation';
 
 type EvalOptions = {
-  evalListItem?: boolean;
   scopeObject?: Record<string, any>;
   overrideScope?: boolean;
   fallbackWhenError?: (exp: string) => any;

--- a/packages/runtime/__tests__/expression.spec.ts
+++ b/packages/runtime/__tests__/expression.spec.ts
@@ -28,7 +28,7 @@ describe('evalExpression function', () => {
   stateManager.store = reactive<Record<string, any>>(scope);
   stateManager.mute = true;
   it('can eval {{}} expression', () => {
-    const evalOptions = { evalListItem: false };
+    const evalOptions = {};
 
     expect(stateManager.deepEval('value', evalOptions)).toEqual('value');
     expect(stateManager.deepEval('{{true}}', evalOptions)).toEqual(true);
@@ -58,26 +58,15 @@ describe('evalExpression function', () => {
   });
 
   it('will not return Proxy', () => {
-    const evalOptions = { evalListItem: false };
-    const fetchData = stateManager.deepEval('{{fetch.data}}', evalOptions);
+    const fetchData = stateManager.deepEval('{{fetch.data}}');
     expect(isProxy(fetchData)).toBe(false);
   });
 
   it('can eval $listItem expression', () => {
-    expect(
-      stateManager.deepEval('{{ $listItem.value }}', {
-        evalListItem: false,
-      })
-    ).toEqual('{{ $listItem.value }}');
-    expect(
-      stateManager.deepEval('{{ $listItem.value }}', {
-        evalListItem: true,
-      })
-    ).toEqual('foo');
+    expect(stateManager.deepEval('{{ $listItem.value }}')).toEqual('foo');
     expect(
       stateManager.deepEval(
-        '{{ {{$listItem.value}}Input.value + {{$moduleId}}Fetch.value }}!',
-        { evalListItem: true }
+        '{{ {{$listItem.value}}Input.value + {{$moduleId}}Fetch.value }}!'
       )
     ).toEqual('Yes, ok!');
   });

--- a/packages/runtime/src/components/_internal/ImplWrapper/ImplWrapperMain.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper/ImplWrapperMain.tsx
@@ -12,7 +12,7 @@ import ComponentErrorBoundary from '../ComponentErrorBoundary';
 
 export const ImplWrapperMain = React.forwardRef<HTMLDivElement, ImplWrapperProps>(
   function ImplWrapperMain(props, ref) {
-    const { component: c, children, evalListItem, slotContext } = props;
+    const { component: c, children, slotContext } = props;
     const { registry, stateManager } = props.services;
     const slotKey = slotContext?.slotKey || '';
 
@@ -37,7 +37,6 @@ export const ImplWrapperMain = React.forwardRef<HTMLDivElement, ImplWrapperProps
         executeTrait(
           t,
           stateManager.deepEval(t.properties, {
-            evalListItem,
             slotKey,
             fallbackWhenError: () => undefined,
           })
@@ -68,7 +67,6 @@ export const ImplWrapperMain = React.forwardRef<HTMLDivElement, ImplWrapperProps
             });
           },
           {
-            evalListItem,
             slotKey,
             fallbackWhenError: () => undefined,
           }
@@ -80,7 +78,7 @@ export const ImplWrapperMain = React.forwardRef<HTMLDivElement, ImplWrapperProps
       // because mergeState will be called during the first render of component, and state will change
       setTraitResults(c.traits.map((trait, i) => executeTrait(trait, properties[i])));
       return () => stops.forEach(s => s());
-    }, [c.id, c.traits, executeTrait, stateManager, evalListItem, slotKey]);
+    }, [c.id, c.traits, executeTrait, stateManager, slotKey]);
 
     // reduce traitResults
     const propsFromTraits: TraitResult<
@@ -113,7 +111,6 @@ export const ImplWrapperMain = React.forwardRef<HTMLDivElement, ImplWrapperProps
       return merge(
         stateManager.deepEval(c.properties, {
           fallbackWhenError: () => undefined,
-          evalListItem,
           slotKey,
         }),
         propsFromTraits
@@ -127,7 +124,6 @@ export const ImplWrapperMain = React.forwardRef<HTMLDivElement, ImplWrapperProps
           setEvaledComponentProperties({ ...newResult });
         },
         {
-          evalListItem,
           fallbackWhenError: () => undefined,
           slotKey,
         }
@@ -136,7 +132,7 @@ export const ImplWrapperMain = React.forwardRef<HTMLDivElement, ImplWrapperProps
       setEvaledComponentProperties({ ...result });
 
       return stop;
-    }, [c.properties, stateManager, evalListItem, slotKey]);
+    }, [c.properties, stateManager, slotKey]);
 
     useEffect(() => {
       const clearFunctions = propsFromTraits?.componentDidMount?.map(e => e());

--- a/packages/runtime/src/components/_internal/ImplWrapper/hooks/useRuntimeFunctions.ts
+++ b/packages/runtime/src/components/_internal/ImplWrapper/hooks/useRuntimeFunctions.ts
@@ -5,7 +5,7 @@ import { merge } from 'lodash';
 import { HandlerMap } from '../../../../services/handler';
 
 export function useRuntimeFunctions(props: ImplWrapperProps) {
-  const { component: c, services, slotContext, evalListItem } = props;
+  const { component: c, services, slotContext } = props;
   const { stateManager, registry, globalHandlerMap } = services;
   const slotKey = slotContext?.slotKey || '';
 
@@ -37,10 +37,9 @@ export function useRuntimeFunctions(props: ImplWrapperProps) {
         subscribeMethods,
         services,
         slotKey,
-        evalListItem,
       });
     },
-    [c.id, evalListItem, mergeState, registry, services, slotKey, subscribeMethods]
+    [c.id, mergeState, registry, services, slotKey, subscribeMethods]
   );
   return {
     mergeState,

--- a/packages/runtime/src/components/_internal/ModuleRenderer.tsx
+++ b/packages/runtime/src/components/_internal/ModuleRenderer.tsx
@@ -39,14 +39,13 @@ const ModuleRendererContent = React.forwardRef<
 >((props, ref) => {
   const { moduleSpec, properties, handlers, evalScope, services, app } = props;
   const moduleId = services.stateManager.deepEval(props.id, {
-    evalListItem: true,
     scopeObject: evalScope,
   }) as string | ExpressionError;
 
   function evalObject<T extends Record<string, any> = Record<string, any>>(
     obj: T
   ): PropsAfterEvaled<T> {
-    const evalOptions = { evalListItem: true, scopeObject: evalScope };
+    const evalOptions = { scopeObject: evalScope };
 
     return services.stateManager.deepEval(obj, evalOptions) as PropsAfterEvaled<T>;
   }
@@ -62,7 +61,6 @@ const ModuleRendererContent = React.forwardRef<
   const evaledStateMap = useMemo(() => {
     // stateMap only use state i
     return services.stateManager.deepEval(moduleSpec.spec.stateMap, {
-      evalListItem: false,
       scopeObject: { $moduleId: moduleId },
       overrideScope: true,
     });
@@ -74,7 +72,6 @@ const ModuleRendererContent = React.forwardRef<
     return services.stateManager.deepEval(
       { template: parsedTemplate },
       {
-        evalListItem: false,
         scopeObject: {
           ...evaledProperties,
           $moduleId: moduleId,
@@ -130,7 +127,6 @@ const ModuleRendererContent = React.forwardRef<
       const moduleEventHandler = ({ fromId, eventType }: Record<string, string>) => {
         if (eventType === h.type && fromId === moduleId) {
           const evaledHandler = services.stateManager.deepEval(h, {
-            evalListItem: true,
             scopeObject: evalScope,
           });
           services.apiService.send('uiMethod', {

--- a/packages/runtime/src/components/core/List.tsx
+++ b/packages/runtime/src/components/core/List.tsx
@@ -97,7 +97,6 @@ export default implementRuntimeComponent({
           services={services}
           childrenMap={{}}
           isInModule
-          evalListItem
           slotContext={{
             renderSet: new Set(),
             slotKey: formatSlotKey(component.id, 'content', `content_${i}`),

--- a/packages/runtime/src/services/StateManager.ts
+++ b/packages/runtime/src/services/StateManager.ts
@@ -16,7 +16,6 @@ dayjs.extend(LocalizedFormat);
 dayjs.locale('zh-cn');
 
 type EvalOptions = {
-  evalListItem?: boolean;
   scopeObject?: Record<string, any>;
   overrideScope?: boolean;
   fallbackWhenError?: (exp: string) => any;
@@ -104,11 +103,11 @@ export class StateManager {
   };
 
   private _maskedEval(raw: string, options: EvalOptions = {}): unknown | ExpressionError {
-    const { evalListItem = false, fallbackWhenError } = options;
+    const { fallbackWhenError } = options;
     let result: unknown[] = [];
 
     try {
-      const expChunk = parseExpression(raw, evalListItem);
+      const expChunk = parseExpression(raw);
 
       if (typeof expChunk === 'string') {
         return expChunk;
@@ -229,6 +228,7 @@ export class StateManager {
         const isDynamicExpression =
           typeof value === 'string' &&
           parseExpression(value).some(exp => typeof exp !== 'string');
+        console.log('isDynamicExpression', value, isDynamicExpression);
 
         if (!isDynamicExpression) return;
 

--- a/packages/runtime/src/services/StateManager.ts
+++ b/packages/runtime/src/services/StateManager.ts
@@ -228,7 +228,6 @@ export class StateManager {
         const isDynamicExpression =
           typeof value === 'string' &&
           parseExpression(value).some(exp => typeof exp !== 'string');
-        console.log('isDynamicExpression', value, isDynamicExpression);
 
         if (!isDynamicExpression) return;
 

--- a/packages/runtime/src/traits/core/Event.tsx
+++ b/packages/runtime/src/traits/core/Event.tsx
@@ -26,7 +26,7 @@ export default implementRuntimeTrait({
     state: {},
   },
 })(() => {
-  return ({ trait, handlers, services, evalListItem, slotKey }) => {
+  return ({ trait, handlers, services, slotKey }) => {
     const callbackQueueMap: Record<string, Array<() => void>> = {};
     const rawHandlers = trait.properties.handlers;
     // setup current handlers
@@ -37,7 +37,7 @@ export default implementRuntimeTrait({
         callbackQueueMap[handler.type] = [];
       }
       callbackQueueMap[handler.type].push(
-        runEventHandler(handler, rawHandlers, Number(i), services, slotKey, evalListItem)
+        runEventHandler(handler, rawHandlers, Number(i), services, slotKey)
       );
     }
 
@@ -60,7 +60,7 @@ export default implementRuntimeTrait({
           () => {
             handlers.forEach((h, i) => {
               if (h.type === MountEvent.mount) {
-                runEventHandler(h, rawHandlers, i, services, slotKey, evalListItem)();
+                runEventHandler(h, rawHandlers, i, services, slotKey)();
               }
             });
           },
@@ -69,7 +69,7 @@ export default implementRuntimeTrait({
           () => {
             handlers.forEach((h, i) => {
               if (h.type === MountEvent.update) {
-                runEventHandler(h, rawHandlers, i, services, slotKey, evalListItem)();
+                runEventHandler(h, rawHandlers, i, services, slotKey)();
               }
             });
           },
@@ -78,7 +78,7 @@ export default implementRuntimeTrait({
           () => {
             handlers.forEach((h, i) => {
               if (h.type === MountEvent.unmount) {
-                runEventHandler(h, rawHandlers, i, services, slotKey, evalListItem)();
+                runEventHandler(h, rawHandlers, i, services, slotKey)();
               }
             });
           },

--- a/packages/runtime/src/types/component.ts
+++ b/packages/runtime/src/types/component.ts
@@ -21,7 +21,6 @@ export type ImplWrapperProps<
   services: UIServices;
   isInModule: boolean;
   app: RuntimeApplication;
-  evalListItem?: boolean;
   slotContext?: { renderSet: Set<string>; slotKey?: string };
 } & ComponentParamsFromApp;
 

--- a/packages/runtime/src/types/trait.ts
+++ b/packages/runtime/src/types/trait.ts
@@ -25,7 +25,6 @@ export type TraitImpl<TProperties = any> = (
       trait: RuntimeTraitSchema<TProperties>;
       componentId: string;
       services: UIServices;
-      evalListItem?: boolean;
       slotKey: string;
     }
 ) => TraitResult<ReadonlyArray<string>, ReadonlyArray<string>>;

--- a/packages/runtime/src/utils/runEventHandler.ts
+++ b/packages/runtime/src/utils/runEventHandler.ts
@@ -11,15 +11,13 @@ export const runEventHandler = (
   rawHandlers: string | PropsBeforeEvaled<Static<typeof CallbackSpec>>,
   index: number,
   services: UIServices,
-  slotKey: string,
-  evalListItem?: boolean
+  slotKey: string
 ) => {
   const { stateManager } = services;
   const send = () => {
     // Eval before sending event to assure the handler object is evaled from the latest state.
     const evalOptions = {
       slotKey,
-      evalListItem,
     };
     const evaledHandlers = stateManager.deepEval(rawHandlers, evalOptions) as Static<
       typeof EventCallBackHandlerSpec

--- a/packages/shared/__tests__/expression.spec.ts
+++ b/packages/shared/__tests__/expression.spec.ts
@@ -36,22 +36,4 @@ describe('parseExpression function', () => {
         ]
       `);
   });
-
-  it('can parse $listItem expression', () => {
-    expect(parseExpression('{{ $listItem.value }}')).toMatchObject([
-      '{{ $listItem.value }}',
-    ]);
-    expect(parseExpression('{{ $listItem.value }}', true)).toMatchObject([
-      [' $listItem.value '],
-    ]);
-    expect(
-      parseExpression(
-        '{{ {{$listItem.value}}input.value + {{$moduleId}}fetch.value }}!',
-        true
-      )
-    ).toMatchObject([
-      [' ', ['$listItem.value'], 'input.value + ', ['$moduleId'], 'fetch.value '],
-      '!',
-    ]);
-  });
 });

--- a/packages/shared/src/utils/expression.ts
+++ b/packages/shared/src/utils/expression.ts
@@ -1,19 +1,11 @@
-import { EXPRESSION, LIST_ITEM_EXP, LIST_ITEM_INDEX_EXP } from '../constants/expression';
+import { EXPRESSION } from '../constants/expression';
 
 export type ExpChunk = string | ExpChunk[];
 
 // copy and modify from
 // https://stackoverflow.com/questions/68161410/javascript-parse-multiple-brackets-recursively-from-a-string
-export const parseExpression = (rawExp: string, parseListItem = false): ExpChunk[] => {
+export const parseExpression = (rawExp: string): ExpChunk[] => {
   const exp = rawExp.trim();
-  // $listItem cannot be evaled in stateStore, so don't mark it as dynamic
-  // unless explicitly pass parseListItem as true
-  if (
-    (exp.includes(LIST_ITEM_EXP) || exp.includes(LIST_ITEM_INDEX_EXP)) &&
-    !parseListItem
-  ) {
-    return [exp];
-  }
 
   function lexer(str: string): string[] {
     let token = '';


### PR DESCRIPTION
Remove the special handling of `$listItem` and `$i` in `parseExpression` to listen for changes in the properties content with these two attributes (currently most scenarios where these two are used are as property of `$slot`, no longer requires special treatment)      

For scenarios where $listItem and $i are used directly, the original spec should be evaled  

Resolves #622  
