### PR TITLE
fix(CodeEditor): editing styles will override cssProperties

### DIFF
--- a/packages/editor/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/editor/src/components/CodeEditor/CodeEditor.tsx
@@ -29,6 +29,14 @@ export const CodeEditor: React.FC<{
 }) => {
   const valueRef = useRef(defaultCode);
   const [rerenderFlag, setRerenderFlag] = useState(0);
+
+  // react-codemirror2 only updates onBlur in componentDidMount
+  // This causes the cssProperties in the `props.onBlur` closure context
+  // to always be the same as when the component was mounted, thus overwriting the latest cssProperties
+  // So subsequent onBlur triggers will use ref to get the latest props.onBlur to get the new closure context
+  // see https://github.com/scniro/react-codemirror2/blob/master/src/index.tsx#L204
+  // https://github.com/scniro/react-codemirror2/blob/master/src/index.tsx#L756
+  // https://github.com/scniro/react-codemirror2/issues/142
   const blurRef = useRef<((v: string) => void) | undefined>(undefined);
   blurRef.current = onBlur;
 

--- a/packages/editor/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/editor/src/components/CodeEditor/CodeEditor.tsx
@@ -29,6 +29,9 @@ export const CodeEditor: React.FC<{
 }) => {
   const valueRef = useRef(defaultCode);
   const [rerenderFlag, setRerenderFlag] = useState(0);
+  const blurRef = useRef<((v: string) => void) | undefined>(undefined);
+  blurRef.current = onBlur;
+
   const style = css`
     .CodeMirror {
       height: 100%;
@@ -56,7 +59,7 @@ export const CodeEditor: React.FC<{
         onChange?.(v);
       }}
       onBlur={() => {
-        onBlur?.(valueRef.current);
+        blurRef.current?.(valueRef.current);
       }}
       options={{
         mode: mode || 'css',

--- a/packages/editor/src/services/EditorStore.ts
+++ b/packages/editor/src/services/EditorStore.ts
@@ -80,7 +80,6 @@ export class EditorStore {
       setComponents: action,
       setHoverComponentId: action,
       setDragOverComponentId: action,
-      setHoverComponentId: action,
     });
 
     this.eventBus.on('selectComponent', id => {


### PR DESCRIPTION
The reason for this bug is that the `UnControlled` component of `react-codemirror2` only updates [onBlur](https://github.com/scniro/react-codemirror2/blob/master/src/index.tsx#L204) in [componentDidMount](https://github.com/scniro/react-codemirror2/blob/master/src/index.tsx#L756), so subsequent calls to onBlur always get the cssProperties from the component mount in the closure context, thus overriding subsequent changes to the cssProperties